### PR TITLE
Added openSUSE Tumbleweed instructions to Installation

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -7,10 +7,10 @@ Hyprland.
 
 ### Distros
 
-Arch and NixOS are very supported. For any other distro (not based on Arch/Nix)
-you might have varying amounts of success. However, since Hyprland is extremely
-bleeding-edge, distros like Pop!\_OS, Ubuntu, etc. might have **major** issues
-running Hyprland.
+Arch, NixOS and openSUSE Tumbleweed are very supported. For any other distro
+(not based on Arch/Nix) you might have varying amounts of success. However,
+since Hyprland is extremely bleeding-edge, distros like Pop!\_OS, Ubuntu, etc.
+might have **major** issues running Hyprland.
 
 # Installation
 
@@ -43,6 +43,21 @@ hyprland-bin - compiled latest release, prone to breaking on ARM devices as Hypr
 
 {{< /tab >}}
 {{< tab "Nix" >}}Read the [Nix page](../../Nix).{{< /tab >}}
+{{< tab "openSUSE" >}}
+There are [precompiled packages of Hyprland](https://build.opensuse.org/package/show/X11:Wayland/hyprland)
+available in the [X11:Wayland](https://build.opensuse.org/project/show/X11:Wayland) project on OBS.
+
+To install them, follow the instructions on [software.opensuse.org/download.html?project=X11:Wayland&package=hyprland](https://software.opensuse.org//download.html?project=X11%3AWayland&package=hyprland) or use [OPI](https://github.com/openSUSE/opi) to install it.
+
+```sh
+$ opi hyprland
+```
+
+Alternativly, you can also follow the instructions under ["Manual (Manual Build)"](#manual-manual-build)
+to build Hyprland yourself.
+
+Note: *Hyprland is not available for Leap, as most libraries (and compiler) that Hyprland needs are to old.*
+{{< /tab >}}
 {{< tab "Fedora" >}}<https://github.com/hyprwm/Hyprland/discussions/284>{{< /tab >}}
 {{< tab "Gentoo" >}}
 The hyprland package is available in the [wayland-desktop](https://github.com/bsd-ac/wayland-desktop) overlay.
@@ -82,6 +97,14 @@ yay -S gdb ninja gcc cmake libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes 
 
 (If any are missing hmu)
 
+*openSUSE dependencies*:
+
+```sh
+zypper in gcc-c++ git meson cmake "pkgconfig(cairo)" "pkgconfig(egl)" "pkgconfig(gbm)" "pkgconfig(gl)" "pkgconfig(glesv2)" "pkgconfig(libdrm)" "pkgconfig(libinput)" "pkgconfig(libseat)" "pkgconfig(libudev)" "pkgconfig(pango)" "pkgconfig(pangocairo)" "pkgconfig(pixman-1)" "pkgconfig(vulkan)" "pkgconfig(wayland-client)" "pkgconfig(wayland-protocols)" "pkgconfig(wayland-scanner)" "pkgconfig(wayland-server)" "pkgconfig(xcb)" "pkgconfig(xcb-icccm)" "pkgconfig(xcb-renderutil)" "pkgconfig(xkbcommon)" "pkgconfig(xwayland)" glslang-devel Mesa-libGLESv3-devel "pkgconfig(xcb-errors)"
+```
+
+(this should also work on RHEL/Fedora if your remove `Mesa-libGLESv3-devel` and `pkgconfig(xcb-errors)`)
+
 Please note Hyprland builds `wlroots`. Make sure you have the dependencies of
 wlroots installed, you can make sure you have them by installing wlroots
 separately (Hyprland doesn't mind)
@@ -102,7 +125,7 @@ sudo make install
 ```plain
 meson _build
 ninja -C _build
-ninja -C _build install
+ninja -C _build install --tags runtime,man
 ```
 
 Refer to [Debugging](../../Contributing-and-Debugging) to see how to build &

--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -47,16 +47,16 @@ hyprland-bin - compiled latest release, prone to breaking on ARM devices as Hypr
 There are [precompiled packages of Hyprland](https://build.opensuse.org/package/show/X11:Wayland/hyprland)
 available in the [X11:Wayland](https://build.opensuse.org/project/show/X11:Wayland) project on OBS.
 
-To install them, follow the instructions on [software.opensuse.org/download.html?project=X11:Wayland&package=hyprland](https://software.opensuse.org//download.html?project=X11%3AWayland&package=hyprland) or use [OPI](https://github.com/openSUSE/opi) to install it.
+To install them, follow the instructions at [software.opensuse.org/download.html?project=X11:Wayland&package=hyprland](https://software.opensuse.org//download.html?project=X11%3AWayland&package=hyprland) or use [OPI](https://github.com/openSUSE/opi) to install it.
 
 ```sh
 $ opi hyprland
 ```
 
-Alternativly, you can also follow the instructions under ["Manual (Manual Build)"](#manual-manual-build)
+Alternatively, you can also follow the instructions under ["Manual (Manual Build)"](#manual-manual-build)
 to build Hyprland yourself.
 
-Note: *Hyprland is not available for Leap, as most libraries (and compiler) that Hyprland needs are to old.*
+Note: *Hyprland is not available for Leap, as most libraries (and compiler) that Hyprland needs are too old.*
 {{< /tab >}}
 {{< tab "Fedora" >}}<https://github.com/hyprwm/Hyprland/discussions/284>{{< /tab >}}
 {{< tab "Gentoo" >}}
@@ -103,7 +103,7 @@ yay -S gdb ninja gcc cmake libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes 
 zypper in gcc-c++ git meson cmake "pkgconfig(cairo)" "pkgconfig(egl)" "pkgconfig(gbm)" "pkgconfig(gl)" "pkgconfig(glesv2)" "pkgconfig(libdrm)" "pkgconfig(libinput)" "pkgconfig(libseat)" "pkgconfig(libudev)" "pkgconfig(pango)" "pkgconfig(pangocairo)" "pkgconfig(pixman-1)" "pkgconfig(vulkan)" "pkgconfig(wayland-client)" "pkgconfig(wayland-protocols)" "pkgconfig(wayland-scanner)" "pkgconfig(wayland-server)" "pkgconfig(xcb)" "pkgconfig(xcb-icccm)" "pkgconfig(xcb-renderutil)" "pkgconfig(xkbcommon)" "pkgconfig(xwayland)" glslang-devel Mesa-libGLESv3-devel "pkgconfig(xcb-errors)"
 ```
 
-(this should also work on RHEL/Fedora if your remove `Mesa-libGLESv3-devel` and `pkgconfig(xcb-errors)`)
+(this should also work on RHEL/Fedora if you remove `Mesa-libGLESv3-devel` and `pkgconfig(xcb-errors)`)
 
 Please note Hyprland builds `wlroots`. Make sure you have the dependencies of
 wlroots installed, you can make sure you have them by installing wlroots


### PR DESCRIPTION
I've packaged Hyprland for openSUSE: https://build.opensuse.org/package/show/X11:Wayland/hyprland,  
these are the instructions to install it (or build from source).

The package currently patches Hyprland twice, @vaxerski you might consider merging them?
- it drops the deprecated `gethostbyname("localhost")` call in `hyprctl/main.cpp`, as binaries calling this should not be part of openSUSE (should use getaddrinfo instead); but in this case the call seems to be leftover from a previous iteration anyways and of little use. [gethostbyname.patch](https://opi-proxy.opensuse.org/?obs_api_link=https%3A%2F%2Fapi.opensuse.org%2Fsource%2FX11%3AWayland%2Fhyprland%2Fgethostbyname.patch&obs_instance=openSUSE)
- it patches the <compiler>.get_version() to <compiler>.version() in `meson.build`, as the get_version() method was seemingly only introduced recently and the version() method was there since forever. This would allow building hyprland with older meson verions (but in the case of the package it was useless, since every distro shipping an outdated meson also had outdated libraries). [old-meson.patch](https://opi-proxy.opensuse.org/?obs_api_link=https%3A%2F%2Fapi.opensuse.org%2Fsource%2FX11%3AWayland%2Fhyprland%2Fold-meson.patch&obs_instance=openSUSE)

I also fixed the meson install instructions. This way it avoids installing the headers and pkg-config file of wlroots.