### PR TITLE
Correct unit for input:repeat_rate

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -127,7 +127,7 @@ _[More about Animations](../Animations)._
 | kb_file | If you prefer, you can use a path to an .xkb file. | str | \[EMPTY\] |
 | follow_mouse | (0/1/2/3) enable mouse following (focus on enter new window) - See the note below for more info | int | 1 |
 | float_switch_override_focus | if enabled (1 or 2), focus will follow mouse if changing from tiled to floating and vice versa. 2 will also follow mouse on float -> float switches | int | 1 |
-| repeat_rate | in ms, the repeat rate for held keys | int | 25 |
+| repeat_rate | in repeats per second, the repeat rate for held keys | int | 25 |
 | repeat_delay | in ms, the repeat delay (grace period) before the spam | int | 600 |
 | natural_scroll | enable natural scroll | bool | false |
 | numlock_by_default | lock numlock by default | bool | false |


### PR DESCRIPTION
The documentation states it's in milliseconds, but in practice it's currently interpreted as Hz.