### PR TITLE
Make togglesplit requirements clear

### DIFF
--- a/pages/Configuring/Dwindle-Layout.md
+++ b/pages/Configuring/Dwindle-Layout.md
@@ -50,4 +50,4 @@ category name: `dwindle`
 |---|---|---|
 | togglegroup | toggles the current window and its siblings (recursively) into a group | none |
 | changegroupactive | switches to the next window in a group. | b - back, f - forward. |
-| togglesplit | toggles the split (top/side) of the current window | none |
+| togglesplit | toggles the split (top/side) of the current window. preserve_split must be enabled for toggling to take effect. | none |

--- a/pages/Configuring/Dwindle-Layout.md
+++ b/pages/Configuring/Dwindle-Layout.md
@@ -50,4 +50,4 @@ category name: `dwindle`
 |---|---|---|
 | togglegroup | toggles the current window and its siblings (recursively) into a group | none |
 | changegroupactive | switches to the next window in a group. | b - back, f - forward. |
-| togglesplit | toggles the split (top/side) of the current window. preserve_split must be enabled for toggling to take effect. | none |
+| togglesplit | toggles the split (top/side) of the current window. `preserve_split` must be enabled for toggling to work. | none |


### PR DESCRIPTION
preserve_split has to be enabled for togglesplit to do anything. This makes sense, but it isn't clear from the documentation.