### PR TITLE
Add necessary dependencies for building on Arch

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -93,10 +93,10 @@ libwlroots), you don't need to update anything else.
 _Arch dependencies_:
 
 ```plain
-yay -S gdb ninja gcc cmake libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite xorg-xinput libxrender pixman wayland-protocols cairo pango seatd
+yay -S gdb ninja gcc cmake libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite xorg-xinput libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland
 ```
 
-_(If any are missing, hmu)_
+_(Please make a pull request or open an issue if any packages are missing from the list)_
 
 _openSUSE dependencies_:
 


### PR DESCRIPTION
I just did a fresh arch install and Hyprland wouldn't build without installing `libxkbcommon`, `xcb-util-wm`, and `xorg-xwayland` in addition to the dependencies already on the wiki. This PR adds these to the list of dependencies so people in the future don't have to go searching for what's missing.

Also updates the text just below the list of dependencies, as requested on the discord server.