### PR TITLE
Help prevent errors

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -63,6 +63,7 @@ The hyprland package is available in the [wayland-desktop](https://github.com/bs
 
 ```sh
 eselect repository enable wayland-desktop
+emaint sync -r wayland-desktop
 emerge --ask --verbose hyprland
 ```
 


### PR DESCRIPTION
adding ``emaint sync -r wayland-desktop`` will help prevent non-existent directory errors when trying to install hyprland on gentoo.