### PR TITLE
Changed Wrong File Name

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -79,12 +79,12 @@ copy the binary (Hyprland) to `/usr/bin/`.
 
 copy hyprctl to `/usr/bin/`.
 
-copy the wlroots .so (`wlroots.so.XX032`) to `/usr/lib/`.
+copy the wlroots .so (`libwlroots.so.XX032`) to `/usr/lib/`.
 
-copy the desktop entry (`examples/Hyprland.desktop`) to
+copy the desktop entry (`examples/hyprland.desktop`) to
 `/usr/share/wayland-sessions/`
 
-the example config is in `examples/Hyprland.conf`.
+the example config is in `examples/hyprland.conf`.
 
 For updating later on, you can overwrite the binaries (hyprctl, hyprland and
 libwlroots), you don't need to update anything else.


### PR DESCRIPTION
Changed wrong file names in the release install guide to match the ones in the actual release tarball.