### PR TITLE
Restyled the Status Bar page

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -73,7 +73,7 @@ emerge --ask --verbose hyprland
 
 ### Manual (Releases)
 
-Download the most recent release.
+Download the [most recent release](https://github.com/hyprwm/Hyprland/releases).
 
 copy the binary (Hyprland) to `/usr/bin/`.
 
@@ -212,7 +212,7 @@ sudo cp ./build/Hyprland /usr/bin && sudo cp ./example/hyprland.desktop /usr/sha
 You can launch Hyprland by either going into a TTY and executing `Hyprland`, or
 with a login manager.
 
-**!IMPORTANT**: Do **not** launch Hyprland with `root` permissions (don't
+**IMPORTANT**: Do **NOT** launch Hyprland with `root` permissions (don't
 `sudo`)
 
 Login managers are not officially supported, but here's a short compatibility

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -93,4 +93,4 @@ You can install it from the AUR by the name `hybrid-bar` or `hybrid-bar-git`.
 The configuration is done through JSON, more information is available [here](https://github.com/vars1ty/HybridBar).
 
 {{</ tab >}}
-{{< /tabs >}}
+{{</ tabs >}}

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -1,3 +1,5 @@
+Status bars on Hyprland.
+
 {{< tabs "uniqueid" >}}
 
 {{< tab "Waybar" >}} Waybar is a GTK status bar made specifically for wlroots compositors.

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -1,8 +1,8 @@
-# Waybar
+{{< tabs "uniqueid" >}}
 
-Waybar is a GTK status bar made specifically for wlroots compositors.
+{{< tab "Waybar" >}} Waybar is a GTK status bar made specifically for wlroots compositors.
 
-To use it, it's recommended to use the AUR package `waybar-hyprland-git`.
+If you are on Arch Linux, It is recommended to use the AUR packages `waybar-hyprland` or `waybar-hyprland-git`.
 
 ## Compiling Manually
 
@@ -16,7 +16,6 @@ meson --prefix=/usr --buildtype=plain --auto-features=enabled --wrap-mode=nodown
 meson configure -Dexperimental=true build
 sudo ninja -C build install
 ```
-
 If you want to use the workspaces module, first, copy the configuration files from
 `/etc/xdg/waybar/` into `~/.config/waybar/`. Then, in `~/.config/waybar/conf/` replace
 all the references to `sway/workspaces` with `wlr/workspaces`.
@@ -24,6 +23,8 @@ all the references to `sway/workspaces` with `wlr/workspaces`.
 For more info regarding configuration, see
 [The Waybar Wiki](https://github.com/Alexays/Waybar/wiki).
 
+
+# Troubleshoot
 ## Waybar popups render behind the windows
 
 In `~/.config/waybar/config`, make sure that you have the `layer` configuration
@@ -53,12 +54,17 @@ the `sed` command used before building Waybar: the default way to select a works
 clicking uses the `swaymsg`'s way, and thus it is required to edit
 this function to make it work with `hyprctl`.
 
-# Eww
+{{< /tab >}}
 
-In order to use [Eww](https://github.com/elkowar/eww), you first have to install
+
+
+
+
+{{< tab "Eww" >}}In order to use [Eww](https://github.com/elkowar/eww), you first have to install
 it, either using your distro's package manager, by searching `eww-wayland`, or
 by manually compiling. In the latter case, you can follow the
 [instructions](https://elkowar.github.io/eww).
+
 
 ## Configuration
 
@@ -73,12 +79,16 @@ Read
 carefully before asking why your bar doesn't work.
 {{< /hint >}}
 
-# Hybrid
+{{< /tab >}}
 
+{{< tab "Hybrid" >}}
 Like Waybar, [Hybrid](https://github.com/vars1ty/HybridBar) is a GTK status bar mainly focused for wlroots compositors.
 
-You can install it from the AUR by the name `hybrid-bar`.
+You can install it from the AUR by the name `hybrid-bar` or `hybrid-bar-git`.
 
 ## Configuration
 
 The configuration is done through JSON, more information is available [here](https://github.com/vars1ty/HybridBar).
+
+{{</ tab >}}
+{{< /tabs >}}


### PR DESCRIPTION
The info of 3 separate bars with different config styles displayed back to back made it look very convoluted so I decided to separate all their info into different tabs just like we have in the _Installation_ page.

Also if y'all like this layout...shall I_re-lay_ the App Clients page like this aswell? 