### PR TITLE
Add information about blurring HybridBar

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -82,3 +82,14 @@ You can install it from the AUR by the name `hybrid-bar`.
 ## Configuration
 
 The configuration is done through JSON, more information is available [here](https://github.com/vars1ty/HybridBar).
+
+### Blur
+
+To activate blur, set `blurls=NAMESPACE` in your hyprland configuration, where `NAMESPACE` is the gtk-layer-shell namespace of your HybridBar. The default namespace is `gtk-layer-shell` and can be changed in the HybridBar configuration at 
+```json
+{
+     "hybrid" {
+          "namespace": "namespace name"
+     }
+}
+```


### PR DESCRIPTION
Adds information how to archive blur on HybridBar using hyprland. I hope I did use the right terms in the change.
This PR depends on https://github.com/vars1ty/HybridBar/pull/27 to be merged to allow setting the layer namespace, else the part about being able to change the namespace name should be removed.
