### PR TITLE
Fix Master-Layout.md

### DIFF
--- a/pages/Configuring/Master-Layout.md
+++ b/pages/Configuring/Master-Layout.md
@@ -17,9 +17,9 @@ However, you can resize the master window.
 _category name `master`_
 
 | name | description | type | default |
-|---|---|---|---|---|
+|---|---|---|---|
 | special_scale_factor | (0.0 - 1.0) the scale of the special workspace windows | float | 0.8 |
-| new_is_master | whether a newly open window should replace the master or join the slaves. | bool | false |
+| new_is_master | whether a newly open window should replace the master or join the slaves. | bool | true |
 | new_on_top | whether a newly open window should be on the top of the stack | bool | false |
 | no_gaps_when_only | whether to apply gaps when there is only one window on a workspace, aka. smart gaps. | bool | false |
 


### PR DESCRIPTION
Fixed:
- Invalid markdown syntax on one of the tables
- Default value of `new_is_master` was incorrectly stated as `false`
  See https://github.com/hyprwm/Hyprland/blob/b2cb3b8bf25e42a44dc53681938ec1399f56d784/src/config/defaultConfig.hpp#L97