### PR TITLE
add a recomended launcher: fuzzel

### DIFF
--- a/pages/Useful Utilities/App-Launchers.md
+++ b/pages/Useful Utilities/App-Launchers.md
@@ -15,3 +15,8 @@ bemenu is a Wayland-native replacement for dmenu.
 
 For a more comprehensive list of launchers, check
 [awesome-wayland](https://github.com/natpen/awesome-wayland#launchers).
+
+## fuzzel
+
+Fuzzel is an application launcher for wlroots based Wayland compositors, similar to rofi's `drun` mode.
+[Codeberg](https://codeberg.org/dnkl/fuzzel)


### PR DESCRIPTION
Fuzzel is an application launcher for wlroots based Wayland compositors, similar to rofi's drun mode. It's source code is on [Codeberg](https://codeberg.org/dnkl/fuzzel)