### PR TITLE
Fixed Useful Utilities link in Configuring/Keywords

### DIFF
--- a/pages/Configuring/Keywords.md
+++ b/pages/Configuring/Keywords.md
@@ -145,7 +145,7 @@ WALLPAPER**, it's the default image rendered at the bottom of the render stack.
 To set a wallpaper, use a wallpaper utility like
 [hyprpaper](https://github.com/hyprwm/hyprpaper) or [swaybg](https://github.com/swaywm/swaybg). 
 
-More can be found in [Useful Utilities](../Useful-Utilities).
+More can be found in [Useful Utilities](<../Useful Utilities/_index.md>).
 
 # Blurring layerSurfaces
 


### PR DESCRIPTION
This link didn't work so I fixed it.