### PR TITLE
add gentoo overlay for xdg-desktop-portal-hyprland

### DIFF
--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -24,13 +24,12 @@ will be disabled)
 ## Installing
 {{< tabs "uniqueid" >}}
 
-{{< tab "Arch Linux" >}} 
+{{< tab "Arch Linux" >}}
 ```plain
 yay -S xdg-desktop-portal-hyprland-git
 ```
 {{< /tab >}}
-{{< tab "Gentoo" >}} 
-
+{{< tab "Gentoo" >}}
 ## Unmask dependencies
 ### /etc/portage/profile/package.unmask
 ```plain
@@ -70,12 +69,13 @@ emaint sync -r useless-overlay
 emerge --ask --verbose gui-libs/xdg-desktop-portal-hyprland
 ```
 
+{{< /tab >}}
+{{< tab "Manual" >}}
+See [The Github repo's readme](https://github.com/hyprwm/xdg-desktop-portal-hyprland).
+
 {{</ tab >}}
 
 {{< /tabs >}}
-
-#### Manual
-See [The Github repo's readme](https://github.com/hyprwm/xdg-desktop-portal-hyprland).
 
 {{< hint type=important >}}
 It's recommended to uninstall any other portal implementations to avoid conflicts with the `-hyprland` or `-wlr` ones.

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -22,18 +22,22 @@ will be disabled)
 {{< /hint >}}
 
 ## Installing
+{{< tabs "uniqueid" >}}
 
-#### AUR
-```sh
+{{< tab "Arch Linux" >}} 
+```plain
 yay -S xdg-desktop-portal-hyprland-git
 ```
-
-### Gentoo
-```
+{{< /tab >}}
+{{< tab "Gentoo" >}} 
+```plain
 eselect repository add useless-overlay git https://github.com/Wa1t5/useless-overlay
 emaint sync -r useless-overlay
 emerge --ask --verbose gui-libs/xdg-desktop-portal-hyprland
 ```
+{{</ tab >}}
+
+{{< /tabs >}}
 
 #### Manual
 See [The Github repo's readme](https://github.com/hyprwm/xdg-desktop-portal-hyprland).

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -31,7 +31,6 @@ yay -S xdg-desktop-portal-hyprland-git
 {{< /tab >}}
 {{< tab "Gentoo" >}} 
 ```plain
-
 ## Unmask dependencies and  enable necessary useflags
 /etc/portage/profile/package.unmask:
 =dev-qt/qtbase-6.4.0

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -39,7 +39,7 @@ yay -S xdg-desktop-portal-hyprland-git
 =dev-qt/qtshadertools-6.4.0
 
 /etc/portage/package.use:
-dev-qt/qtbase opengl X
+dev-qt/qtbase opengl egl eglfs gles2-only
 dev-qt/qtdeclarative opengl
 gui-libs/xdg-desktop-portal-hyprland select-window select-region
 sys-apps/xdg-desktop-portal screencast
@@ -51,7 +51,7 @@ gui-libs/xdg-desktop-portal-hyprland **
 =dev-qt/qtdeclarative-6.4.0
 =dev-qt/qtshadertools-6.4.0
 
-instead of using X on qtbase you could also use egl and eglfs
+btw those are the useflags that I have tested, you could also test others
 
 ## Installation
 eselect repository add useless-overlay git https://github.com/Wa1t5/useless-overlay

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -28,6 +28,13 @@ will be disabled)
 yay -S xdg-desktop-portal-hyprland-git
 ```
 
+### Gentoo
+```
+eselect repository add useless-overlay git https://github.com/Wa1t5/useless-overlay
+emaint sync -r useless-overlay
+emerge --ask --verbose gui-libs/xdg-desktop-portal-hyprland
+```
+
 #### Manual
 See [The Github repo's readme](https://github.com/hyprwm/xdg-desktop-portal-hyprland).
 

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -31,10 +31,35 @@ yay -S xdg-desktop-portal-hyprland-git
 {{< /tab >}}
 {{< tab "Gentoo" >}} 
 ```plain
+
+## Unmask dependencies and  enable necessary useflags
+/etc/portage/profile/package.unmask:
+=dev-qt/qtbase-6.4.0
+=dev-qt/qtwayland-6.4.0
+=dev-qt/qtdeclarative-6.4.0
+=dev-qt/qtshadertools-6.4.0
+
+/etc/portage/package.use:
+dev-qt/qtbase opengl X
+dev-qt/qtdeclarative opengl
+gui-libs/xdg-desktop-portal-hyprland select-window select-region
+sys-apps/xdg-desktop-portal screencast
+
+/etc/portage/package.accept_keywords:
+gui-libs/xdg-desktop-portal-hyprland **
+=dev-qt/qtbase-6.4.0
+=dev-qt/qtwayland-6.4.0
+=dev-qt/qtdeclarative-6.4.0
+=dev-qt/qtshadertools-6.4.0
+
+instead of using X on qtbase you could also use egl and eglfs
+
+## Installation
 eselect repository add useless-overlay git https://github.com/Wa1t5/useless-overlay
 emaint sync -r useless-overlay
 emerge --ask --verbose gui-libs/xdg-desktop-portal-hyprland
 ```
+
 {{</ tab >}}
 
 {{< /tabs >}}

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -30,30 +30,41 @@ yay -S xdg-desktop-portal-hyprland-git
 ```
 {{< /tab >}}
 {{< tab "Gentoo" >}} 
+
+## Unmask dependencies
+### /etc/portage/profile/package.unmask
 ```plain
-## Unmask dependencies and  enable necessary useflags
-/etc/portage/profile/package.unmask:
 =dev-qt/qtbase-6.4.0
 =dev-qt/qtwayland-6.4.0
 =dev-qt/qtdeclarative-6.4.0
 =dev-qt/qtshadertools-6.4.0
+```
 
-/etc/portage/package.use:
+## Apply necessary useflags
+### /etc/portage/package.use
+```plain
 dev-qt/qtbase opengl egl eglfs gles2-only
 dev-qt/qtdeclarative opengl
 gui-libs/xdg-desktop-portal-hyprland select-window select-region
 sys-apps/xdg-desktop-portal screencast
+```
 
-/etc/portage/package.accept_keywords:
+## Unmask dependencies and xdph
+### /etc/portage/package.accept_keywords
+```plain
 gui-libs/xdg-desktop-portal-hyprland **
 =dev-qt/qtbase-6.4.0
 =dev-qt/qtwayland-6.4.0
 =dev-qt/qtdeclarative-6.4.0
 =dev-qt/qtshadertools-6.4.0
+```
 
-btw those are the useflags that I have tested, you could also test others
+btw those are the useflags that I have tested, you could also test others. Also if the gentoo devs update the qt ebuilds without marking them as stable you'll need to check the ebuild version and update it on '/etc/portage/package.accept_keywords' and '/etc/portage/profile/package.unmask'
+
+example: '=dev-qt/qtbase-6.5.0'
 
 ## Installation
+```sh
 eselect repository add useless-overlay git https://github.com/Wa1t5/useless-overlay
 emaint sync -r useless-overlay
 emerge --ask --verbose gui-libs/xdg-desktop-portal-hyprland


### PR DESCRIPTION
I could add more details to  it though actually to install the dependencies on gentoo you need to do these modifications respectively

### /etc/portage/profile/package.unmask:
```
# XDPH
=dev-qt/qtbase-6.4.0
=dev-qt/qtwayland-6.4.0
=dev-qt/qtdeclarative-6.4.0
=dev-qt/qtshadertools-6.4.0
```

### /etc/portage/package.use
```
# XDPH
dev-qt/qtbase opengl X
dev-qt/qtdeclarative opengl
gui-libs/xdg-desktop-portal-hyprland select-window select-region
sys-apps/xdg-desktop-portal screencast
```

### /etc/portage/package.accept_keywords
```
#XDPH
gui-libs/xdg-desktop-portal-hyprland **
=dev-qt/qtbase-6.4.0
=dev-qt/qtwayland-6.4.0
=dev-qt/qtdeclarative-6.4.0
=dev-qt/qtshadertools-6.4.0
```

Instead of X on qtbase you could also use egl and eglfs


