### PR TITLE
fix layout instead of kb_layout

### DIFF
--- a/pages/Configuring/Using-hyprctl.md
+++ b/pages/Configuring/Using-hyprctl.md
@@ -117,7 +117,7 @@ Sets the xkb layout index for a keyboard.
 For example, if you set:
 ```ini
 device:my-epic-keyboard-v1 {
-    layout=us,pl,de
+    kb_layout=us,pl,de
 }
 ```
 


### PR DESCRIPTION
doesn't use the prefix "kb_" for "layout" which results in an error.