### PR TITLE
Fix broken link to list of dispatchers

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -206,7 +206,7 @@ bindr=ALT,Alt_L,exec,amongus
 Yes, you heard this right, Hyprland does support global keybinds for ALL apps,
 including OBS, Discord, Firefox, etc.
 
-See the [`pass` dispatcher](./Dispatchers/#list-of-dispatchers) for keybinds.
+See the [`pass` dispatcher](../Dispatchers/#list-of-dispatchers) for keybinds.
 
 Let's take OBS as an example: the "Start/Stop Recording" keybind is set to 
 <key>SUPER</key> + <key>F10</key>, and you want to make it work globally.


### PR DESCRIPTION
Hey, I found that the link to list of dispatchers in the [Global Keybinds](http://wiki.hyprland.org/Configuring/Binds/#global-keybinds) section of the [Binds](https://wiki.hyprland.org/Configuring/Binds/#global-keybinds) page is currently broken. I have fixed the link with the correct one.

![2023-01-30T17:50:13,498801158+05:30](https://user-images.githubusercontent.com/84301852/215478561-55238627-27ff-4f8e-b31a-ffe0f304977a.png)


