### PR TITLE
update Other.md: Change hyprland-per-window-layout to better fork

### DIFF
--- a/pages/Useful Utilities/Other.md
+++ b/pages/Useful Utilities/Other.md
@@ -4,7 +4,7 @@ Here you will find links to some other projects that may not fit into any of the
 [hyprsome](https://github.com/sopa0/hyprsome) by _sopa0_: Awesome-like workspaces for Hyprland.
 
 ### Keyboard layout management
-[hyprland-per-window-layout](https://github.com/MahouShoujoMivutilde/hyprland-per-window-layout/) by _MahouShoujoMivutilde: Per window keyboard layouts for Hyprland.
+[hyprland-per-window-layout](https://github.com/coffebar/hyprland-per-window-layout/) by _MahouShoujoMivutilde and coffebar_: Per window keyboard layouts for Hyprland.
 
 ### IPC wrappers
 [hyprland-rs](https://github.com/yavko/hyprland-rs) by _yavko_: A neat wrapper for Hyprland's IPC written in Rust.


### PR DESCRIPTION
Change hyprland-per-window-layout to [another](https://github.com/coffebar/hyprland-per-window-layout) version: with zero configuration, multi-keyboard support and available  to install from package manager