### PR TITLE
new solution to disable middle-click paste

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -266,12 +266,14 @@ to use absolute paths, such as `/home/username/Script` instead of `~/Script`
 
 # How to disable middle-click paste?
 
-In your config, add this bind: `bind = , mouse:274, exec, ;`. Note that the
-exact bindcode may vary, so you may want to check it with `wev` first.
+The middle-click paste action pastes from a separate buffer (primary buffer) than what the regular clipboard uses (clipboard buffer). Since the primary buffer is unrelated to the clipboard buffer, it's easy to simply keep the primary buffer empty, allowing the middle-click action to retain the rest of its functionality without having anything to paste. Run the following command (in your config with `exec-once`, for example) to achieve this:
 
-Note that some software, like `kitty`, intercepts middle-click events and binds
-them to paste from primary on their own. Their configurations will need to be
-changed to account for that.
+`wl-paste -p --watch wl-copy -pc` (`wl-paste -p --watch` watches for changes to the primary buffer, `wl-copy -pc` clears the primary buffer)
+
+
+Alternatively, you can simply intercept the middle-click action all together, via hyprland binds for example. The drawbacks to this solution are that 1. it disables the rest of the functionality of the middle-click action, such as auto scroll, closing browser tabs, etc., and 2. many applications (such as kitty) manually intercept the middle-click events and bind them to paste from the primary buffer themselves, bypassing the solution altogether. For this solution, add this bind to your config:
+
+`bind = , mouse:274, exec, ;`. Note that the exact bindcode may vary, so you may want to check it with `wev` first.
 
 # How do I make Hyprland draw as little power as possible on my laptop?
 


### PR DESCRIPTION
`wl-paste -p --watch wl-copy -pc`.
I haven't tested the new solution for *that* long yet, but I'm fairly confident that it works, at least better than the original solution which was already flawed.