### PR TITLE
fix link in Using-Plugins.md

### DIFF
--- a/pages/Plugins/Using-Plugins.md
+++ b/pages/Plugins/Using-Plugins.md
@@ -58,7 +58,7 @@ ask the plugin's maintainer to fix it.
 Yes. `hyprctl plugin unload /path/to/plugin.so`
 
 ### How do I make my own plugin?
-See [here](../Development/Getting-Started.md).
+See [here](../Development/Getting-Started).
 
 ### Where do I find plugins?
 Try looking around [here](https://duckduckgo.com).


### PR DESCRIPTION
I open this link in web and get 404 error, but it can be opened without ".md" just fine 