### PR TITLE
Replaced wofi with rofi

### DIFF
--- a/pages/Useful Utilities/Clipboard-Managers.md
+++ b/pages/Useful Utilities/Clipboard-Managers.md
@@ -52,7 +52,7 @@ Now bind the `clipman` like this:
 
 # For `rofi` users
 ```ini
-bind = SUPER, V, clipman pick -t wofi
+bind = SUPER, V, clipman pick -t rofi
 ```
 
 # For `dmenu` users


### PR DESCRIPTION
In the clipboard manager section for clipman you state `for rofi users` bust instead of showing an example with `rofi` you used `wofi