### PR TITLE
Add libliftoff and libdisplay-info

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -102,7 +102,7 @@ libwlroots), you don't need to update anything else.
 _Arch dependencies_:
 
 ```plain
-yay -S gdb ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite xorg-xinput libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland libinput
+yay -S gdb ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite xorg-xinput libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info
 ```
 
 _(Please make a pull request or open an issue if any packages are missing from the list)_


### PR DESCRIPTION
libdisplay-info (from the AUR) is required for wlroots drm backend, which Hyprland depends on. Failure to install this package results in linking errors at compile time. libliftoff is not a hard requirement (meaning it builds fine without it), but seems useful to include.

I don't know enough about the other distros to include their version of the packages to the list.