### PR TITLE
Add info about using the left or right version of a modkey

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -37,7 +37,7 @@ legacy, e.g. `0xeeb3ff1a` -> ARGB order
 SHIFT CAPS CTRL/CONTROL ALT MOD2 MOD3 SUPER/WIN/LOGO/MOD4 MOD5
 ```
 
-The left or right variant of a mod can be specified by appending "_L" or "_R" to the mod.
+The left or right variant of a mod can be specified by appending "_L" or "_R".
 
 ```ini
 SHIFT_L SHIFT_R CTRL_L CTRL_R ALT_L ALT_R

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -37,6 +37,12 @@ legacy, e.g. `0xeeb3ff1a` -> ARGB order
 SHIFT CAPS CTRL/CONTROL ALT MOD2 MOD3 SUPER/WIN/LOGO/MOD4 MOD5
 ```
 
+The left or right variant of a mod can be specified by appending "_L" or "_R" to the mod.
+
+```ini
+SHIFT_L SHIFT_R CTRL_L CTRL_R ALT_L ALT_R
+```
+
 {{< /hint >}}
 
 # Sections


### PR DESCRIPTION
I couldn't find anywhere in the wiki that it explicitly states how to use left and right mod keys. This fixes that by adding it to the variables page.