### PR TITLE
Update Must-have.md

### DIFF
--- a/pages/Useful Utilities/Must-have.md
+++ b/pages/Useful Utilities/Must-have.md
@@ -37,6 +37,8 @@ Our recommendation is the KDE one. For arch, it's `polkit-kde-agent`.
 
 You can autostart it with `exec-once=/usr/lib/polkit-kde-authentication-agent-1`.
 
+On other distributions that use a more recent version, such as Gentoo, it may be necessary to use `exec-once=/usr/lib64/libexec/polkit-kde-authentication-agent-1` instead.
+
 ### QT Wayland Support
 _Starting method:_ none (just a library)
 


### PR DESCRIPTION
The path to execute the kde polkit agent has changed as of version 5.27.3, and now resides in `/usr/lib64/libexec/polkit-kde-authentication-agent-1` instead. Because of this, the "must-have" page should have its instructions changed to reflect the update.

fixes #160 