### PR TITLE
Change where to find plugins link to point to the github repo than duckduckgo

### DIFF
--- a/pages/Plugins/Using-Plugins.md
+++ b/pages/Plugins/Using-Plugins.md
@@ -111,7 +111,7 @@ Yes. `hyprctl plugin unload /path/to/plugin.so`
 See [here](../Development/Getting-Started).
 
 ### Where do I find plugins?
-Try looking around [here](https://duckduckgo.com).
+Try looking around [here](https://github.com/hyprwm/hyprland-plugins).
 
 ### Are plugins safe?
 As long as you read the source code of your plugin(s) and can see there's nothing bad going on,


### PR DESCRIPTION
As mentioned in the title, I've changed the link in the [Where to find plugins](http://wiki.hyprland.org/Plugins/Using-Plugins/#where-do-i-find-plugins) section to point to the plugins repo rather than duckduckgo.