### PR TITLE
"animate_manual_resizes" default to false

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -237,8 +237,8 @@ Described [here](../Keywords#per-device-input-configs).
 | key_press_enables_dpms | If DPMS is set to off, wake up the monitors if a key is pressed. | bool | false |
 | always_follow_on_dnd | Will make mouse focus follow the mouse when drag and dropping. Recommended to leave it enabled, especially for people using focus follows mouse at 0. | bool | true |
 | layers_hog_keyboard_focus | If true, will make keyboard-interactive layers keep their focus on mouse move (e.g. wofi, bemenu) | bool | true |
-| animate_manual_resizes | If true, will animate manual window resizes/moves | bool | true |
-| animate_mouse_windowdragging | If true, will animate windows being dragged by mouse, note that this can cause weird behavior on some curves | bool | true |
+| animate_manual_resizes | If true, will animate manual window resizes/moves | bool | false |
+| animate_mouse_windowdragging | If true, will animate windows being dragged by mouse, note that this can cause weird behavior on some curves | bool | false |
 | disable_autoreload | If true, the config will not reload automatically on save, and instead needs to be reloaded with `hyprctl reload`. Might save on battery. | bool | false |
 | enable_swallow | Enable window swallowing | bool | false |
 | swallow_regex | The *class* regex to be used for windows that should be swallowed (usually, a terminal) | str | \[EMPTY\] |


### PR DESCRIPTION
Changed default values for "animate_manual_resizes" and "animate_mouse_windowdragging" to _false_ following [this commit](https://github.com/hyprwm/Hyprland/commit/41f7736c8521162cb3ea5f3c003e0643c1bcf616).