### PR TITLE
Add wl-screenrec as suggestion for screen recording

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -61,7 +61,7 @@ GitHub pages).
 For a more complete utility, try our own screenshotting utility:
 [Grimblast](https://github.com/hyprwm/contrib).
 
-For recording videos, [wf-recorder](https://github.com/ammen99/wf-recorder) or [OBS Studio](https://obsproject.com/) could be used.
+For recording videos, [wf-recorder](https://github.com/ammen99/wf-recorder), [wl-screenrec](https://github.com/russelltg/wl-screenrec) or [OBS Studio](https://obsproject.com/) could be used.
 
 # Screenshare / OBS no worky
 


### PR DESCRIPTION
Disclosure: I am the author of wl-screenrec

Add a link to wl-screenrec, a more efficient version of wf-recorder that works for Intel and AMD GPUs. 