### PR TITLE
Added some minor stuff again

### DIFF
--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -128,6 +128,14 @@ will send it to the currently active _real_ workspace.
 You can define multiple named special workspaces, but the amount of those is limited to 97 at a time.
 {{< /hint >}}
 
+For example, to move a window/application to a special workspace you can use the following syntax:
+
+```
+bind = SUPER, C, movetoworkspace, special
+#The above syntax will move the window to a special workspace upon pressing 'SUPER'+'C'.
+#To see the hidden window you can use the togglespecialworkspace dispatcher mentioned above.
+```
+
 # Workspace options
 
 ```txt

--- a/pages/Useful Utilities/Clipboard-Managers.md
+++ b/pages/Useful Utilities/Clipboard-Managers.md
@@ -8,7 +8,7 @@ Some common ones used are `copyq`, `clipman` and `cliphist`.
 
 `cliphist` - Utilizes Wayland with `wl-clipboard` and can store both images and text [Github](https://github.com/sentriz/cliphist) 
 
-`wl-clip-persists` - When we copy something on Wayland and close the application we copied from, the copied data disappears from the clipboard and we cannot paste it anymore. So to fix this problem we can use a program called as `wl-clip-persists` which will preserve the data in the clipboard after the application is closed. [Github](https://github.com/Linus789/wl-clip-persist)
+`wl-clip-persists` - When we copy something on Wayland (using wl-clipboard) and close the application we copied from, the copied data disappears from the clipboard and we cannot paste it anymore. So to fix this problem we can use a program called as `wl-clip-persists` which will preserve the data in the clipboard after the application is closed. [Github](https://github.com/Linus789/wl-clip-persist)
 
 ## cliphist
 

--- a/pages/Useful Utilities/Clipboard-Managers.md
+++ b/pages/Useful Utilities/Clipboard-Managers.md
@@ -8,6 +8,8 @@ Some common ones used are `copyq`, `clipman` and `cliphist`.
 
 `cliphist` - Utilizes Wayland with `wl-clipboard` and can store both images and text [Github](https://github.com/sentriz/cliphist) 
 
+`wl-clip-persists` - When we copy something on Wayland and close the application we copied from, the copied data disappears from the clipboard and we cannot paste it anymore. So to fix this problem we can use a program called as `wl-clip-persists` which will preserve the data in the clipboard after the application is closed. [Github](https://github.com/Linus789/wl-clip-persist)
+
 ## cliphist
 
 Start by adding the following lines to your `~/.config/hypr/hyprland.conf`


### PR DESCRIPTION
Again added some minor stuff to the wiki - 

1) It was important to add the [`wl-clip-persists`](https://github.com/hyprwm/hyprland-wiki/commit/765e1a4ab2499ac9554e1234a35758b397440411) program to the wiki. Normally we use wl-clipboard in wayland to store the copied data (for ex text,images) to our clipboard but there is a problem with it. When we close the application from where we copied the data from the data disappears from the clipboard. For example lets say u are using firefox and discord you copy a text from firefox and paste it in discord. Everything works well !! but now try to copy a text from firefox then close the firefox application and now try to paste the text you copied from firefox into discord (or any other application). It doesn't work :cry: . So `wl-clip-persist` is used so that it can store the data in our clipboard even after the applications exits out.

EDIT: I know that [wl-clip-persist](https://github.com/Linus789/wl-clip-persist) is a niche project but it works!! I couldn't find a better alternative for it.

2) [Special workspace](https://wiki.hyprland.org/Configuring/Dispatchers/#special-workspace) section was not explained properly. Users should know how a special workspace works thats why I gave an [example](https://github.com/hyprwm/hyprland-wiki/commit/709e189094a314629ef63563472e3bf7c8291264) so that people can understand it better.