### PR TITLE
Update Must-have.md

### DIFF
--- a/pages/Useful Utilities/Must-have.md
+++ b/pages/Useful Utilities/Must-have.md
@@ -36,6 +36,7 @@ an app wants to elevate its privileges.
 Our recommendation is the KDE one. For arch, it's `polkit-kde-agent`.
 
 You can autostart it with `exec-once=/usr/lib/polkit-kde-authentication-agent-1`.
+On some distributions you might have to use a different path `/usr/libexec/polkit-kde-authentication-agent-1`.
 
 On other distributions that use a more recent version, such as Gentoo, it may be necessary to use `exec-once=/usr/lib64/libexec/polkit-kde-authentication-agent-1` instead.
 


### PR DESCRIPTION
While using opensuse, i found out ( im a bit of a newbie ) that libexec is in a different path, so i thought of adding it in the docs.