### PR TITLE
Add socat `-U` flag to IPC example

### DIFF
--- a/pages/IPC/_index.md
+++ b/pages/IPC/_index.md
@@ -68,5 +68,5 @@ function handle {
   fi
 }
 
-socat - UNIX-CONNECT:/tmp/hypr/$(echo $HYPRLAND_INSTANCE_SIGNATURE)/.socket2.sock | while read line; do handle $line; done
+socat -U - UNIX-CONNECT:/tmp/hypr/$(echo $HYPRLAND_INSTANCE_SIGNATURE)/.socket2.sock | while read line; do handle $line; done
 ```


### PR DESCRIPTION
As a temporary fix to https://github.com/hyprwm/Hyprland/issues/1564 I think it would be great to add this to the wiki.

I've just added the flag, but I could also write some explanation for it if necessary.