### PR TITLE
Fix shellcheck warnings and optimize code blocks

### DIFF
--- a/pages/Configuring/Expanding-functionality.md
+++ b/pages/Configuring/Expanding-functionality.md
@@ -12,8 +12,8 @@ to react to different events. See its description
 This bash script will change the outer gaps to 20 if the currently focused
 monitor is DP-1, and 30 otherwise.
 
-```sh
-#!/bin/sh
+```bash
+#!/bin/bash
 
 function handle {
   if [[ ${1:0:10} == "focusedmon" ]]; then
@@ -25,5 +25,5 @@ function handle {
   fi
 }
 
-socat - UNIX-CONNECT:/tmp/hypr/$(echo $HYPRLAND_INSTANCE_SIGNATURE)/.socket2.sock | while read line; do handle $line; done
+socat - "UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock" | while read -r line; do handle "$line"; done
 ```

--- a/pages/Configuring/Uncommon-tips-&-tricks.md
+++ b/pages/Configuring/Uncommon-tips-&-tricks.md
@@ -58,8 +58,8 @@ Steam will exit entirely when it's last window is closed using the `killactive` 
 To minimize Steam to tray, use the following script to close applications:
 
 ```sh
-if [[ $(hyprctl activewindow -j | jq -r ".class") == "Steam" ]]; then
-    xdotool windowunmap $(xdotool getactivewindow)
+if [ "$(hyprctl activewindow -j | jq -r ".class")" = "Steam" ]; then
+    xdotool getactivewindow windowunmap
 else
     hyprctl dispatch killactive ""
 fi
@@ -122,8 +122,8 @@ For increased performance in games, or for less distractions at a keypress
 
 ```bash
 #!/usr/bin/env sh
-HYPRGAMEMODE=$(hyprctl getoption animations:enabled | sed -n '2p' | awk '{print $2}')
-if [ $HYPRGAMEMODE = 1 ] ; then
+HYPRGAMEMODE=$(hyprctl getoption animations:enabled | awk 'NR==2{print $2}')
+if [ "$HYPRGAMEMODE" = 1 ] ; then
     hyprctl --batch "\
         keyword animations:enabled 0;\
         keyword decoration:drop_shadow 0;\

--- a/pages/Configuring/Using-hyprctl.md
+++ b/pages/Configuring/Using-hyprctl.md
@@ -157,7 +157,7 @@ input {
 Sets the hyprctl error string. Will reset when Hyprland's config is reloaded.
 
 ```sh
-hyprctl seterror rgba(66ee66ff) hello world this is my problem
+hyprctl seterror 'rgba(66ee66ff)' hello world this is my problem
 ```
 
 or disable:

--- a/pages/Contributing and Debugging/_index.md
+++ b/pages/Contributing and Debugging/_index.md
@@ -66,7 +66,7 @@ the dump. See the instructions below for more info about `coredumpctl`.
 You can also use the amazing command
 
 ```sh
-watch -n 0.1 "cat /tmp/hypr/$(echo $HYPRLAND_INSTANCE_SIGNATURE)/hyprland.log | grep -v \"arranged\" | tail -n 40"
+watch -n 0.1 "grep -v \"arranged\" /tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/hyprland.log | tail -n 40"
 ```
 
 for live logs. (replace `hyprland` with `hyprlandd` for debug builds)

--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -194,19 +194,19 @@ exec-once=handle_monitor_connect.sh
 
 where `handle_monitor_connect.sh` is: (example)
 
-```bash
+```sh
 #!/bin/sh
 
-function handle {
-  if [[ ${1:0:12} == "monitoradded" ]]; then
+handle() {
+  case $1 in monitoradded*)
     hyprctl dispatch moveworkspacetomonitor "1 1"
     hyprctl dispatch moveworkspacetomonitor "2 1"
     hyprctl dispatch moveworkspacetomonitor "4 1"
     hyprctl dispatch moveworkspacetomonitor "5 1"
-  fi
+  esac
 }
 
-socat - UNIX-CONNECT:/tmp/hypr/.socket2.sock | while read line; do handle $line; done
+socat - UNIX-CONNECT:/tmp/hypr/.socket2.sock | while read -r line; do handle "$line"; done
 ```
 
 if you want workspaces 1 2 4 5 to go to monitor 1 when connecting it.

--- a/pages/IPC/_index.md
+++ b/pages/IPC/_index.md
@@ -63,11 +63,12 @@ example script using socket2 events with bash and `socat`:
 ```sh
 #!/bin/sh
 
-function handle {
-  if [[ ${1:0:12} == "monitoradded" ]]; then
-    # do_something
-  fi
+handle() {
+  case $1 in
+    monitoradded*) do_something ;;
+    focusedmon*) do_something_else ;;
+  esac
 }
 
-socat -U - UNIX-CONNECT:/tmp/hypr/$(echo $HYPRLAND_INSTANCE_SIGNATURE)/.socket2.sock | while read line; do handle $line; done
+socat -U - UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock | while read -r line; do handle "$line"; done
 ```

--- a/pages/Nix/Options & Overrides.md
+++ b/pages/Nix/Options & Overrides.md
@@ -78,7 +78,7 @@ patch wlroots.
 If you're using Nix (and not NixOS or Home Manager) and you want to override,
 you can do it like this
 
-```sh
+```console
 $ nix repl
 nix-repl> :lf "github:hyprwm/Hyprland"
 nix-repl> :bl outputs.packages.x86_64-linux.hyprland.override {nvidiaPatches = true;} # option = value

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -139,7 +139,7 @@ fi
 ```sh
 #!/bin/bash
 hyprctl monitors -j | jq --raw-output .[0].activeWorkspace.id
-socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - | stdbuf -o0 grep '^workspace>>' | stdbuf -o0 awk -F '>>|,' '{print $2}'
+socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - | stdbuf -o0 awk -F '>>|,' '/^workspace>>/{print $2}'
 ```
 
 ### `~/.config/eww/scripts/get-workspaces`
@@ -163,13 +163,13 @@ done
 <details>
 <summary>Active window title widget</summary>
 
-This widget simply displays the title of the active window. It requires [bash](https://linux.die.net/man/1/bash), [awk](https://linux.die.net/man/1/awk), [stdbuf](https://linux.die.net/man/1/stdbuf), [grep](https://linux.die.net/man/1/grep), [socat](https://linux.die.net/man/1/socat), and [jq](https://stedolan.github.io/jq/).
+This widget simply displays the title of the active window. It requires [awk](https://linux.die.net/man/1/awk), [stdbuf](https://linux.die.net/man/1/stdbuf), [socat](https://linux.die.net/man/1/socat), and [jq](https://stedolan.github.io/jq/).
 
 ### `~/.config/eww/eww.yuck`
 
 ```lisp
 ...
-(deflisten window :initial "..." "bash ~/.config/eww/scripts/get-window-title")
+(deflisten window :initial "..." "sh ~/.config/eww/scripts/get-window-title")
 (defwidget window_w []
   (box
     (label :text "${window}"
@@ -181,9 +181,9 @@ This widget simply displays the title of the active window. It requires [bash](h
 ### `~/.config/eww/scripts/get-window-title`
 
 ```sh
-#!/bin/bash
+#!/bin/sh
 hyprctl activewindow -j | jq --raw-output .title
-socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - | stdbuf -o0 grep '^activewindow>>' | stdbuf -o0 awk -F '>>|,' '{print $3}'
+socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - | stdbuf -o0 awk -F '>>|,' '/^activewindow>>/{print $3}'
 ```
 
 </details>


### PR DESCRIPTION
I noticed that the wiki sometimes uses Bashism in `#!/bin/sh` blocks, so I ran [markdown-shellcheck](https://github.com/Ordoviz/markdown-shellcheck) on it to find more issues.