### PR TITLE
Fix: Typo curzor_zoom_rigid -> cursor_zoom_rigid

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -253,7 +253,7 @@ Described [here](../Keywords#per-device-input-configs).
 | render_ahead_of_time | [Warning: buggy] starts rendering _before_ your monitor displays a frame in order to lower latency | bool | false |
 | render_ahead_safezone | how many ms of safezone to add to rendering ahead of time. Recommended 1-2. | int | 1 |
 | cursor_zoom_factor | the factor to zoom by around the cursor. AKA. Magnifying glass. Minimum 1.0 (meaning no zoom) | float | 1.0 |
-| curzor_zoom_rigid | whether the zoom should follow the cursor rigidly (cursor is always centered if it can be) or loosely | bool | false |
+| cursor_zoom_rigid | whether the zoom should follow the cursor rigidly (cursor is always centered if it can be) or loosely | bool | false |
 
 # Binds
 


### PR DESCRIPTION
Changed "curzor_zoom_rigid" -> "cursor_zoom_rigid" documentation to match what's written in the actual codebase 

E.g. https://github.com/hyprwm/Hyprland/blob/28ca434fb52befa2058a6c23b21566c280654e03/src/render/OpenGL.cpp#L148