### PR TITLE
Add "How to launch" section under each status bar tutorial

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -28,6 +28,11 @@ all the references to `sway/workspaces` with `wlr/workspaces`.
 For more info regarding configuration, see
 [The Waybar Wiki](https://github.com/Alexays/Waybar/wiki).
 
+## How to launch
+
+After getting everything set up, you might want to check If Waybar is configured to your liking, to launch it, simply type `waybar` into your terminal.
+If you would like to set Waybar to launch alongside Hyprland, you can do this by going to `~/.config/hypr/hyprland.conf` and adding a line that reads `exec-once=waybar`
+
 ## Waybar popups render behind the windows
 
 In `~/.config/waybar/config`, make sure that you have the `layer` configuration
@@ -197,6 +202,11 @@ You can install it from the AUR by the name `hybrid-bar`.
 ## Configuration
 
 The configuration is done through JSON, more information is available [here](https://github.com/vars1ty/HybridBar).
+
+## How to launch
+
+After configuring Hybrid, you can launch it by typing `hybrid-bar` into your terminal to try it out.
+It is also possible to set it to launch at start, to do this you can go to `~/.config/hypr/hyprland.conf` and add a line that reads `exec-once=hybrid-bar`
 
 ### Blur
 

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -30,7 +30,7 @@ For more info regarding configuration, see
 
 ## How to launch
 
-After getting everything set up, you might want to check If Waybar is configured to your liking. To launch it, simply type `waybar` into your terminal.
+After getting everything set up, you might want to check if Waybar is configured to your liking. To launch it, simply type `waybar` into your terminal.
 If you would like to set Waybar to launch alongside Hyprland, you can do this by adding a line to your Hyprland configuration file (located at `~/.config/hypr/hyprland.conf` by default) that reads `exec-once=waybar`
 
 ## Waybar popups render behind the windows

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -31,7 +31,7 @@ For more info regarding configuration, see
 ## How to launch
 
 After getting everything set up, you might want to check if Waybar is configured to your liking. To launch it, simply type `waybar` into your terminal.
-If you would like to set Waybar to launch alongside Hyprland, you can do this by adding a line to your Hyprland configuration file (located at `~/.config/hypr/hyprland.conf` by default) that reads `exec-once=waybar`
+If you would like waybar to launch alongside hyprland, you can do this by adding a line to your hyprland configuration that reads `exec-once=waybar`
 
 ## Waybar popups render behind the windows
 
@@ -205,8 +205,8 @@ The configuration is done through JSON, more information is available [here](htt
 
 ## How to launch
 
-After configuring Hybrid, you can launch it by typing `hybrid-bar` into your terminal to try it out.
-It is also possible to set it to launch at start, to do this you can add a line to your Hyprland configuration file (located at `~/.config/hypr/hyprland.conf` by default) that reads `exec-once=hybrid-bar`
+After configuring HybridBar, you can launch it by typing `hybrid-bar` into your terminal to try it out.
+It is also possible to set it to launch at start, to do this you can add a line to your hyprland configuration that reads `exec-once=hybrid-bar`
 
 ### Blur
 

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -31,7 +31,7 @@ For more info regarding configuration, see
 ## How to launch
 
 After getting everything set up, you might want to check If Waybar is configured to your liking. To launch it, simply type `waybar` into your terminal.
-If you would like to set Waybar to launch alongside Hyprland, you can do this by going to `~/.config/hypr/hyprland.conf` and adding a line that reads `exec-once=waybar`
+If you would like to set Waybar to launch alongside Hyprland, you can do this by adding a line to your Hyprland configuration file (located at `~/.config/hypr/hyprland.conf` by default) that reads `exec-once=waybar`
 
 ## Waybar popups render behind the windows
 
@@ -206,7 +206,7 @@ The configuration is done through JSON, more information is available [here](htt
 ## How to launch
 
 After configuring Hybrid, you can launch it by typing `hybrid-bar` into your terminal to try it out.
-It is also possible to set it to launch at start, to do this you can go to `~/.config/hypr/hyprland.conf` and add a line that reads `exec-once=hybrid-bar`
+It is also possible to set it to launch at start, to do this you can add a line to your Hyprland configuration file (located at `~/.config/hypr/hyprland.conf` by default) that reads `exec-once=hybrid-bar`
 
 ### Blur
 

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -30,7 +30,7 @@ For more info regarding configuration, see
 
 ## How to launch
 
-After getting everything set up, you might want to check If Waybar is configured to your liking, to launch it, simply type `waybar` into your terminal.
+After getting everything set up, you might want to check If Waybar is configured to your liking. To launch it, simply type `waybar` into your terminal.
 If you would like to set Waybar to launch alongside Hyprland, you can do this by going to `~/.config/hypr/hyprland.conf` and adding a line that reads `exec-once=waybar`
 
 ## Waybar popups render behind the windows


### PR DESCRIPTION
I'm not sure how to use Eww, so It would be better if someone with better understanding of that added a "How to launch" section under the Eww section.