### PR TITLE
Removed the need for XDPH to pull latest git for gentoo

### DIFF
--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -55,7 +55,7 @@ sys-apps/xdg-desktop-portal screencast
 ## Unmask dependencies and xdph
 ### /etc/portage/package.accept_keywords
 ```plain
-gui-libs/xdg-desktop-portal-hyprland **
+gui-libs/xdg-desktop-portal-hyprland 
 dev-qt/qtbase
 dev-qt/qtwayland
 dev-qt/qtdeclarative


### PR DESCRIPTION
XDPH doesn't need ** keyword, it means portage will pull in the latest git version of XDPH available, which at the time of writing the wiki may have been required, but is not necessary now.

Removing ** will just pull the latest available package available(i.e assume ~amd64) on the gentoo overlay, which is sufficient.