### PR TITLE
add xwayland screensharing documentation

### DIFF
--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -14,3 +14,17 @@ for a great tutorial.
 ## Better screensharing
 
 See [the hyprland portal page](../Hyprland-desktop-portal)
+
+## XWayland
+
+If your screensharing application is running under XWayland (like Discord, Skype,...), it can only see other XWayland windows and cannot share an entire screen or a Wayland window.
+
+The KDE-team has implemented a workaround for this called [xwaylandvideobridge](https://invent.kde.org/system/xwaylandvideobridge). There is currently an issue preventing it from working with Hyprland by default, but you can fix that by applying [this patch](https://aur.archlinux.org/cgit/aur.git/plain/cursor-mode.patch?h=xwaylandvideobridge-cursor-mode-2-git) or by using [this AUR package](https://aur.archlinux.org/packages/xwaylandvideobridge-cursor-mode-2-git).
+
+Note that Hyprland currently doesn't support the way it tries to hide the main window, so you will have to create some window-rules to archive the same effect. See [this issue](https://invent.kde.org/system/xwaylandvideobridge/-/issues/1) for more information. For example:
+```ini
+windowrulev2 = opacity 0.0 override 0.0 override,class:^(xwaylandvideobridge)$
+windowrulev2 = noanim,class:^(xwaylandvideobridge)$
+windowrulev2 = nofocus,class:^(xwaylandvideobridge)$
+windowrulev2 = noinitialfocus,class:^(xwaylandvideobridge)$
+```


### PR DESCRIPTION
Recently learned about [xwaylandvideobridge](https://invent.kde.org/system/xwaylandvideobridge) which is a very user friendly way to enable screensharing of Wayland applications and Screens for Apps runnuing under XWayland. 

Since it takes some workarounds to get it working with Hyprland i thought it would be nice to have it documented here since it's currently not described in the gist. 

Please feel free to correct me if i put in some misinformation about Hyprlands ability to hide windows but this was the easiest way i could find.