### PR TITLE
Fix: Improve XDP(s) processes termination.

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -235,7 +235,7 @@ In such cases, a script like this:
 ```bash
 #!/bin/bash
 sleep 4
-killall xdg-desktop-portal-wlr
+killall -e xdg-desktop-portal-wlr
 killall xdg-desktop-portal
 /usr/lib/xdg-desktop-portal-wlr &
 sleep 4

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -106,8 +106,8 @@ For a nuclear option, you can use this script and `exec-once` it:
 ```sh
 #!/bin/bash
 sleep 1
-killall xdg-desktop-portal-hyprland
-killall xdg-desktop-portal-wlr
+killall -e xdg-desktop-portal-hyprland
+killall -e xdg-desktop-portal-wlr
 killall xdg-desktop-portal
 /usr/lib/xdg-desktop-portal-hyprland &
 sleep 2


### PR DESCRIPTION
Improve `xdg-desktop-portals` processes termination since `xdg-desktop-portals` is 19 characters long.

From `killall(1)` man page:

> -e, --exact
>
> Require an exact match for very long names. If a command name is longer
> than 15 characters, the full name may be unavailable (i.e. it is swapped
> out). In this case, `killall` will kill everything that matches within
> the first 15 characters. With -e, such entries are skipped. `killall`
> prints a message for each skipped entry if -v is specified in addition
> to -e.