### PR TITLE
Added screenshot utility/flameshot stuff at _index.md

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -288,3 +288,11 @@ Read [this trick](../Configuring/Uncommon-tips--tricks/#window-dancing).
 See [The XDPH Page](../Useful-Utilities/Hyprland-desktop-portal).
 
 You most likely have multiple portal impls / an impl is failing to launch.
+
+# My screenshot utilities won't work with multiple screens
+Some programs like flameshot (currently) has limited wayland support so on most Wayland compositors, you will have to do few tweaks.
+For Hyprland, you can add these window rules to your config to make said programs work with both of your screens.
+```windowrulev2=float,title:^(flameshot)
+windowrulev2=move 0 0,title:^(flameshot)
+windowrulev2=nofullscreenrequest,title:^(flameshot)
+```


### PR DESCRIPTION
programs like flameshot won't capture both of your screens most of the time, so I thought adding a small tutorial to make them work on multimon setups to the FAQ would be helpful.

There is also the matter of flameshot being extremely slow on selection on Hyprland, which I have a workaround for, which might be worth adding but it is a little hacky, so I didn't put it here and it might not even be relevant soon because the workaround already requires compiling a PR (which I would have to create a tutorial for and might not be worth it since it might get merged) and installing a package from the AUR if the user is on Arch Linux. (and so on)

I didn't think it would be appropriate to add it here but if you think I should, I would be happy to add it to this PR.