### PR TITLE
Add hyprland instance signature to handle_monitor_connect.sh

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -206,7 +206,7 @@ handle() {
   esac
 }
 
-socat - UNIX-CONNECT:/tmp/hypr/.socket2.sock | while read -r line; do handle "$line"; done
+socat - "UNIX-CONNECT:/tmp/hypr/${HYPRLAND_INSTANCE_SIGNATURE}/.socket2.sock" | while read -r line; do handle "$line"; done
 ```
 
 if you want workspaces 1 2 4 5 to go to monitor 1 when connecting it.


### PR DESCRIPTION
When I tried this tip from the wiki to handle monitor connects, I discovered that the event socket is now namespaced with the instance id.

This makes this tip work with version 0.26.0-3 (arch package).