### PR TITLE
Add Void Linux Installation tab

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -91,6 +91,16 @@ Refer to the gist if anything fails.
 {{< /hint >}}
 
 {{</ tab >}}
+{{< tab "Void Linux" >}}
+Hyprland is not available for Void Linux from the official repositories [as Hyprland does build against tagged wlroots](https://github.com/void-linux/void-packages/issues/37544),
+however template files are available [from a third party](https://github.com/Makrennel/hyprland-void) which can build Hyprland [using xbps-src](https://github.com/void-linux/void-packages).
+
+For further instructions on building with the third party resource, refer to the [README](https://github.com/Makrennel/hyprland-void/blob/master/README.md).
+
+{{< hint type=warning >}}
+As always, when using third party scripts exercise caution and understand what the script does.
+{{< /hint>}}
+{{< /tab >}}
 
 {{< /tabs >}}
 


### PR DESCRIPTION
It isn't available in the official Void Linux repositories, but I've created template files which can build it using xbps-src consistently: https://github.com/Makrennel/hyprland-void

I figured it'd be good to share it given how many useless issues have been made regarding void linux build problems.