### PR TITLE
Nix/HM: add instructions for upstream module

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -1,7 +1,5 @@
-You can use the Home Manager module by adding it to your configuration:
-
 For a list of available options, check the
-[module file](https://github.com/hyprwm/Hyprland/blob/main/nix/hm-module.nix).
+[Home Manager options](https://nix-community.github.io/home-manager/options.html#opt-wayland.windowManager.hyprland.enable).
 
 {{< hint title=Note >}}
 - *(Required) NixOS Module*: enables critical components needed to run Hyprland properly
@@ -10,13 +8,24 @@ For a list of available options, check the
 
 ## Installation
 
-The following snippets of code try to show how to bring the Hyprland flake from
-the flake input and import it into the module system. Feel free to make any
-adjustment for your setup.
-
 {{< tabs "uniqueid" >}}
 
+{{< tab "Home Manager" >}}
+
+Home Manager has options for Hyprland without needing to import the Flake module.
+
+```nix
+{
+  wayland.windowManager.hyprland.enable = true;
+}
+```
+
+{{< /tab >}}
 {{< tab "Flakes" >}}
+
+The following snippet of code tries to show how to bring the Hyprland flake from
+the flake input and import it into the module system. Feel free to make any
+adjustment for your setup.
 
 Don't forget to replace `user@hostname` with your username and hostname!
 
@@ -51,6 +60,12 @@ Don't forget to replace `user@hostname` with your username and hostname!
 {{< /tab >}}
 
 {{< tab "No flakes (with flake-compat)" >}}
+
+The following snippet of code tries to show how to bring the Hyprland flake from
+the flake input and import it into the module system. Feel free to make any
+adjustment for your setup.
+
+
 ```nix
 # home config
 
@@ -82,11 +97,40 @@ in {
 
 ## Usage
 
-Once the module is enabled, you can use it to declaratively configure Hyprland:
+Once the module is enabled, you can use it to declaratively configure Hyprland.
+Here is an example config, made to work with either the upstream Home Manager
+module, or the Flake-based Home Manager module.
 
 ```nix
 # home.nix
 {config, pkgs, ...}: {
+  # hyprland module from HM
+  wayland.windowManager.hyprland.settings = {
+    "$mod" = "SUPER";
+    bind =
+      [
+        "$mod, F, exec, firefox"
+        ", Print, exec, grimblast copy area"
+      ]
+      ++ (
+        # workspaces
+        # binds $mod + [shift +] {1..10} to [move to] workspace {1..10}
+        builtins.concatLists (builtins.genList (
+            x: let
+              ws = let
+                c = (x + 1) / 10;
+              in
+                builtins.toString (x + 1 - (c * 10));
+            in [
+              "$mod, ${ws}, workspace, ${toString (x + 1)}"
+              "$mod SHIFT, ${ws}, movetoworkspace, ${toString (x + 1)}"
+            ]
+          )
+          10)
+      );
+  };
+
+  # hyprland module from the flake
   wayland.windowManager.hyprland.extraConfig = ''
     $mod = SUPER
 

--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -2,9 +2,11 @@ For a list of available options, check the
 [Home Manager options](https://nix-community.github.io/home-manager/options.html#opt-wayland.windowManager.hyprland.enable).
 
 {{< hint title=Note >}}
-- *(Required) NixOS Module*: enables critical components needed to run Hyprland properly
-- *(Optional) Home-manager module*: lets you declaratively configure Hyprland
-{{< /hint >}}
+
+- _(Required) NixOS Module_: enables critical components needed to run Hyprland
+  properly
+- _(Optional) Home-manager module_: lets you declaratively configure Hyprland
+  {{< /hint >}}
 
 ## Installation
 
@@ -12,7 +14,8 @@ For a list of available options, check the
 
 {{< tab "Home Manager" >}}
 
-Home Manager has options for Hyprland without needing to import the Flake module.
+Home Manager has options for Hyprland without needing to import the Flake
+module.
 
 ```nix
 {
@@ -21,7 +24,16 @@ Home Manager has options for Hyprland without needing to import the Flake module
 ```
 
 {{< /tab >}}
+
 {{< tab "Flakes" >}}
+
+{{< hint >}}
+
+The flake module is merely an extension to the Home Manager downstream module.
+It is mainly used as a staging area for new options, so unless you're a tester
+you should use the downstream Home Manager module.
+
+{{< /hint >}}
 
 The following snippet of code tries to show how to bring the Hyprland flake from
 the flake input and import it into the module system. Feel free to make any
@@ -57,14 +69,22 @@ Don't forget to replace `user@hostname` with your username and hostname!
   };
 }
 ```
+
 {{< /tab >}}
 
 {{< tab "No flakes (with flake-compat)" >}}
 
+{{< hint >}}
+
+The flake module is merely an extension to the Home Manager downstream module.
+It is mainly used as a staging area for new options, so unless you're a tester
+you should use the downstream Home Manager module.
+
+{{< /hint >}}
+
 The following snippet of code tries to show how to bring the Hyprland flake from
 the flake input and import it into the module system. Feel free to make any
 adjustment for your setup.
-
 
 ```nix
 # home config
@@ -76,35 +96,27 @@ adjustment for your setup.
     src = builtins.fetchTarball "https://github.com/hyprwm/Hyprland/archive/master.tar.gz";
   }).defaultNix;
 in {
-  imports = [
-    hyprland.homeManagerModules.default
-  ];
+  imports = [hyprland.homeManagerModules.default];
 
-  wayland.windowManager.hyprland = {
-    enable = true;
-
-    extraConfig = ''
-      bind = SUPER, Return, exec, kitty
-      # ...
-    '';
-  };
+  wayland.windowManager.hyprland.enable = true;
 }
 ```
+
 {{< /tab >}}
 
 {{< /tabs >}}
 
+};
 
 ## Usage
 
 Once the module is enabled, you can use it to declaratively configure Hyprland.
 Here is an example config, made to work with either the upstream Home Manager
-module, or the Flake-based Home Manager module.
+module, or the flake-based Home Manager module.
 
 ```nix
 # home.nix
-{config, pkgs, ...}: {
-  # hyprland module from HM
+{
   wayland.windowManager.hyprland.settings = {
     "$mod" = "SUPER";
     bind =
@@ -129,37 +141,12 @@ module, or the Flake-based Home Manager module.
           10)
       );
   };
-
-  # hyprland module from the flake
-  wayland.windowManager.hyprland.extraConfig = ''
-    $mod = SUPER
-
-    bind = $mod, F, exec, firefox
-    bind = , Print, exec, grimblast copy area
-
-    # workspaces
-    # binds $mod + [shift +] {1..10} to [move to] workspace {1..10}
-    ${builtins.concatStringsSep "\n" (builtins.genList (
-        x: let
-          ws = let
-            c = (x + 1) / 10;
-          in
-            builtins.toString (x + 1 - (c * 10));
-        in ''
-          bind = $mod, ${ws}, workspace, ${toString (x + 1)}
-          bind = $mod SHIFT, ${ws}, movetoworkspace, ${toString (x + 1)}
-        ''
-      )
-      10)}
-
-    # ...
-  '';
 }
 ```
 
 ## Plugins
 
-Hyprland plugins can be added through an option:
+Hyprland plugins can be added through the `plugins` option:
 
 ```nix
 wayland.windowManager.hyprland.plugins = [
@@ -168,45 +155,41 @@ wayland.windowManager.hyprland.plugins = [
 ];
 ```
 
-For examples on how to build hyprland plugins using nix see the
+For examples on how to build Hyprland plugins using nix see the
 [official plugins](https://github.com/hyprwm/hyprland-plugins).
 
 ## Fixing problems with themes
 
-If your themes for mouse cursor, icons or windows don't load correctly, try setting them with `home.pointerCursor` and `gtk.theme`, which enable a bunch of compatibility options that should make the themes load in all situations.
+If your themes for mouse cursor, icons or windows don't load correctly, try
+setting them with `home.pointerCursor` and `gtk.theme`, which enable a bunch of
+compatibility options that should make the themes load in all situations.
 
 Example configuration:
-```
-  home-manager = {
-    useGlobalPkgs = true;
-    useUserPackages = true;
-    users.username = {
-      home = {
-        stateVersion = "23.05";
-        pointerCursor = {
-          gtk.enable = true;
-          # x11.enable = true;
-          package = pkgs.bibata-cursors;
-          name = "Bibata-Modern-Amber";
-          size = 32;
-        };
-      };
-      gtk = {
-        enable = true;
-        theme = {
-          package = pkgs.flat-remix-gtk;
-          name = "Flat-Remix-GTK-Grey-Darkest";
-        };
-        iconTheme = {
-          package = pkgs.libsForQt5.breeze-icons;
-          name = "breeze-dark";
-        };
-        font = {
-          name = "Sans";
-          size = 11;
-        };
-      };
-    };
+
+```nix
+home.pointerCursor = {
+  gtk.enable = true;
+  # x11.enable = true;
+  package = pkgs.bibata-cursors;
+  name = "Bibata-Modern-Classic";
+  size = 16;
+};
+
+gtk = {
+  enable = true;
+  theme = {
+    package = pkgs.flat-remix-gtk;
+    name = "Flat-Remix-GTK-Grey-Darkest";
   };
-   
+
+  iconTheme = {
+    package = pkgs.gnome.adwaita-icon-theme;
+    name = "Adwaita";
+  };
+
+  font = {
+    name = "Sans";
+    size = 11;
+  };
+};
 ```

--- a/pages/Nix/_index.md
+++ b/pages/Nix/_index.md
@@ -1,13 +1,16 @@
 To install Hyprland on NixOS, we provide a NixOS and a Home Manager module.
 
 {{< hint title=Note >}}
-- *(Required) NixOS Module*: enables critical components needed to run Hyprland properly
-- *(Optional) Home-manager module*: lets you declaratively configure Hyprland
-{{< /hint >}}
+
+- _(Required) NixOS Module_: enables critical components needed to run Hyprland
+  properly
+- _(Optional) Home-manager module_: lets you declaratively configure Hyprland
+  {{< /hint >}}
 
 ## NixOS module
 
-The module is now upstreamed into Nixpkgs, which means all you need in your configuration is:
+The module is now upstreamed into Nixpkgs, which means all you need in your
+configuration is:
 
 ```nix
 {config, pkgs, ...}: {
@@ -17,7 +20,8 @@ The module is now upstreamed into Nixpkgs, which means all you need in your conf
 }
 ```
 
-Note that the command to run hyprland is `Hyprland` (with a capital `H`) and not `hyprland`.
+Note that the command to run hyprland is `Hyprland` (with a capital `H`) and not
+`hyprland`.
 
 For more options, see
 [module options](https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=hyprland).
@@ -27,6 +31,10 @@ For other NixOS options, see [Hyprland on NixOS](./Hyprland-on-NixOS).
 ## Home-manager module
 
 Read [Hyprland on Home Manager](./Hyprland-on-Home-Manager).
+
+For the adventurous, [@spikespaz](https://github.com/spikespaz) has made a
+Hyprland module that can be used in Home Manager and NixOS. It can be found
+[here](https://github.com/spikespaz/hyprland-nix).
 
 ## Options and overrides
 


### PR DESCRIPTION
Adds instructions on how to use the upstream Home Manager module for Hyprland.
Will probably undergo some changes as the HM module needs a few changes.

Fixes #272