### PR TITLE
Fix broken link to `xwayland-hidpi.patch` & `wlroots-hidpi.patch`

### DIFF
--- a/pages/Configuring/XWayland.md
+++ b/pages/Configuring/XWayland.md
@@ -19,11 +19,11 @@ and [Pacman patching](https://wiki.archlinux.org/title/Patching_packages).
 {{< /hint >}}
 
 1. Have the latest `xwayland` package patched with at least
-    [the HiDPI patch](https://github.com/hyprwm/Hyprland/blob/main/nix/xwayland-hidpi.patch)
+    [the HiDPI patch](https://github.com/hyprwm/Hyprland/blob/main/nix/patches/xwayland-hidpi.patch)
     (based on the MR's implementation, but updated).
 
 2. Make sure you have the required Hyprland `wlroots`, patched with
-    [the HiDPI xwayland patch](https://github.com/hyprwm/Hyprland/blob/main/nix/wlroots-hidpi.patch)
+    [the HiDPI xwayland patch](https://github.com/hyprwm/Hyprland/blob/main/nix/patches/wlroots-hidpi.patch)
     and [this commit](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/18595000f3a21502fd60bf213122859cc348f9af)
     **reverted**. This is important, as not reverting it will make opening
     XWayland programs crash Hyprland.


### PR DESCRIPTION
This commit fixes the broken links to `wlroots-hidpi.patch` and `xwayland-hidpi.patch` on the XWayland page.

The files were moved to patches subdirectory in https://github.com/hyprwm/Hyprland/commit/91e3c654d309c7723bef374cd4d1a0198a16ba53

fixes https://github.com/hyprwm/hyprland-wiki/issues/277