### PR TITLE
Master Tutorial: Fix SDDM version requirement

### DIFF
--- a/pages/Getting Started/Master-Tutorial.md
+++ b/pages/Getting Started/Master-Tutorial.md
@@ -41,7 +41,7 @@ path, ignoring a check for the above, etc.
 Login managers are not officially supported, but here's a short compatibility
 list:
 
-- SDDM → Works flawlessly. Install the [latest git version](https://github.com/sddm/sddm) (or [sddm-git](https://aur.archlinux.org/packages/sddm-git) from the AUR if you use Arch) to prevent SDDM bug [1476](https://github.com/sddm/sddm/issues/1476) (90s shutdowns).
+- SDDM → Works flawlessly. Install sddm ⩾ 0.20.0 or the [latest git version](https://github.com/sddm/sddm) (or [sddm-git](https://aur.archlinux.org/packages/sddm-git) from AUR) to prevent SDDM bug [1476](https://github.com/sddm/sddm/issues/1476) (90s shutdowns).
 - GDM → Works with the caveat of crashing Hyprland on the first launch
 - ly → Works poorly
 


### PR DESCRIPTION
SDDM >= 0.20.0 has fixed https://github.com/sddm/sddm/issues/1476 and it's no longer necessary to install the lastest development version.