### PR TITLE
groups: document `movewindoworgroup` and other changes

### DIFF
--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -67,7 +67,9 @@ layout pages (See the sidebar).
 | lockactivegroup | Lock the focused group (the current group will not accept new windows or be moved to other groups) | `lock` for locking, `unlock` for unlocking, `toggle` for toggle |
 | moveintogroup | Moves the active window into a group in a specified direction. No-op if there is no group in the specified direction. | direction |
 | moveoutofgroup | Moves the active window out of a group. No-op if not in a group | none |
+| movewindoworgroup | Behaves as `moveintogroup` if there is a group in the given direction. Behaves as `moveoutofgroup` if there is no group in the given direction relative to the active group. Otherwise behaves like `movewindow`. | none |
 | movegroupwindow | Swaps the active window with the next or previous in a group | `b` for back, anything else for forward |
+| setignoregrouplock | Temporarily enable or disable binds:ignore_group_lock | `on`, `off`, or `toggle` |
 | global | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) | name |
 | submap | Change the current mapping group. See [Submaps](../Binds/#submaps) | `reset` or name |
 

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -268,7 +268,6 @@ Described [here](../Keywords#per-device-input-configs).
 | swallow_exception_regex | The *title* regex to be used for windows that should *not* be swallowed by the windows specified in swallow_regex  (e.g. wev). The regex is matched against the parent (e.g. Kitty) window's title on the assumption that it changes to whatever process it's running. | str | \[\[Empty\]\] |
 | focus_on_activate | Whether Hyprland should focus an app that requests to be focused (an `activate` request) | bool | false |
 | no_direct_scanout | Disables direct scanout. Direct scanout attempts to reduce lag when there is only one fullscreen application on a screen (e.g. game). It is also recommended to set this to true if the fullscreen application shows graphical glitches. | bool | true |
-| moveintogroup_lock_check | Enable to check if groups are locked before moving window/group to target group. | bool | false |
 | hide_cursor_on_touch | Hides the cursor when the last input was a touch input until a mouse input is done. | bool | true |
 | mouse_move_focuses_monitor | Whether mouse moving into a different monitor should focus it | bool | true |
 | suppress_portal_warnings | disables warnings about incompatible portal implementations. | bool | false |
@@ -278,6 +277,7 @@ Described [here](../Keywords#per-device-input-configs).
 | cursor_zoom_rigid | whether the zoom should follow the cursor rigidly (cursor is always centered if it can be) or loosely | bool | false |
 | allow_session_lock_restore | if true, will allow you to restart a lockscreen app in case it crashes (red screen of death) | bool | false |
 | group_insert_after_current | whether new windows in a group spawn after current or at group tail | bool | true |
+| group_focus_removed_window | whether Hyprland should focus on the window that has just been moved out of the group | bool | true |
 | render_titles_in_groupbar | whether to render titles in the group bar decoration | bool | true |
 | groupbar_titles_font_size | font size for the above | int | 8 |
 | groupbar_gradients | whether to draw gradients under the titles of the above | bool | true |
@@ -293,6 +293,7 @@ Described [here](../Keywords#per-device-input-configs).
 | workspace_back_and_forth | If enabled, an attempt to switch to the currently focused workspace will instead switch to the previous workspace. Akin to i3's *auto_back_and_forth*. | bool | false |
 | allow_workspace_cycles | If enabled, workspaces don't forget their previous workspace, so cycles can be created by switching to the first workspace in a sequence, then endlessly going to the previous workspace. | bool | false |
 | focus_preferred_method | sets the preferred focus finding method when using `focuswindow`/`movewindow`/etc with a direction. 0 - history (recent have priority), 1 - length (longer shared edges have priority) | int | 0 |
+| ignore_group_lock | If enabled, dispatchers like `moveintogroup`, `moveoutofgroup` and `movewindoworgroup` will ignore lock per group. | bool | false |
 
 # XWayland
 

--- a/pages/IPC/_index.md
+++ b/pages/IPC/_index.md
@@ -50,6 +50,7 @@ e.g.: `workspace>>2`
 | minimize | emitted when a window requests a change to its minimized state. `MINIMIZED` is either 0 or 1. | `WINDOWADDRESS,MINIMIZED` |
 | screencast | emitted when a screencopy state of a client changes. Keep in mind there might be multiple separate clients. State is 0/1, owner is 0 - monitor share, 1 - window share | `STATE,OWNER` |
 | windowtitle | emitted when a window title changes. | `WINDOWADDRESS` |
+| ignoregrouplock | emitted when ignoregrouplock is toggled. | `0/1` |
 
 {{< hint type=warning >}}
 A fullscreen event is not guaranteed to fire on/off once in succession.


### PR DESCRIPTION
Documentation for hyprwm/Hyprland#3006

New dispatchers:
- `movewindoworgroup`
- `setgrouplockchecking`

New Variables
- `binds:check_group_lock`
- `misc:new_window_in_group`

Removed Variables
- `misc:moveintogroup_lock_check`, replaced by `binds:check_group_lock`