### PR TITLE
Copy empty string into primary clipboard instead of clearing selection

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -230,7 +230,7 @@ env = XDG_CURRENT_DESKTOP,Hyprland
 
 The middle-click paste action pastes from a separate buffer (primary buffer) than what the regular clipboard uses (clipboard buffer). Since the primary buffer is unrelated to the clipboard buffer, it's easy to simply keep the primary buffer empty, allowing the middle-click action to retain the rest of its functionality without having anything to paste. Run the following command (in your config with `exec-once`, for example) to achieve this:
 
-`wl-paste -p --watch wl-copy -pc` (`wl-paste -p --watch` watches for changes to the primary buffer, `wl-copy -pc` clears the primary buffer)
+`wl-paste -p --watch wl-copy -p ''` (`wl-paste -p --watch` watches for changes to the primary buffer, `wl-copy -p ''` clears the primary buffer)
 
 
 Alternatively, you can simply intercept the middle-click action all together, via hyprland binds for example. The drawbacks to this solution are that 1. it disables the rest of the functionality of the middle-click action, such as auto scroll, closing browser tabs, etc., and 2. many applications (such as kitty) manually intercept the middle-click events and bind them to paste from the primary buffer themselves, bypassing the solution altogether. For this solution, add this bind to your config:


### PR DESCRIPTION
I'm using this wl-paste/wl-copy setup to disable middle click, but I've noticed `wl-copy -pc` also clears the selected text in GTK UI elements, which prevents the user from selecting text altogether.

I've found a similar report at https://bugs.kde.org/show_bug.cgi?id=461498. Not sure where the issue lies exactly, but `wl-copy -p ''` accomplishes the same (clearing the primary buffer) without also clearing the selected text.