### PR TITLE
Added a mention to a slackbuild under a new "Slackware" tab.

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -123,6 +123,15 @@ For further instructions on building with the third party resource, refer to the
 As always, when using third party scripts exercise caution and understand what the script does.
 {{< /hint>}}
 {{< /tab >}}
+{{< tab "Slackware" >}}
+```plain
+hyprland-bin (SlackBuilds) - Prebuilt release for Slackware ready for install
+```
+Hyprland is not installed by default on the current release of Slackware.
+
+For detailed instructions on installing this build see [here](https://slackbuilds.org/repository/15.0/desktop/hyprland-bin/)
+
+{{< /tab >}}
 
 {{< /tabs >}}
 


### PR DESCRIPTION
Instead of going into detail, I felt that it might be best only to link, as even though Slackware is not likely to update very soon the slackbuild itself is lagging behind the most current version by a lot, I did not feel comfortable that the instructions from the build would not deviate. I can provide the detailed instructions if you instead feel that this is incorrect.