### PR TITLE
Remove warnings about Spotify not respecting window rules

### DIFF
--- a/pages/Useful Utilities/App-Clients.md
+++ b/pages/Useful Utilities/App-Clients.md
@@ -11,35 +11,6 @@ on the Discord ToS.
 - [gtkcord4](https://github.com/diamondburned/gtkcord4) is a Discord client written in GTK4.
 While it does infringe on Discord's ToS, it's relatively safe and doesn't rely on any webview technologies.
 
-## Spotify
-
-Spotify does not follow window rules. This is because the client sets its class _after_
-the window has opened, thus making it "immune" to windowrules. An alternative to
-Spotify's GUI client is [spotify-tui](https://github.com/Rigellute/spotify-tui) which can be
-launched in a terminal with a custom class. While limited in functionality, it is quite
-powerful and could be preferred over the GUI client. Another alternative is [ncspot](https://github.com/hrkfdn/ncspot), a powerful cross-platform ncurses Spotify client written in Rust.
-
-Some users have also reported [installing spotifywm](https://github.com/dasJ/spotifywm) has resolved
-the issue.
-
-After following the installation paragraph on the README, start Spotify with:
-
-```bash
-LD_PRELOAD=/path/to/spotifywm.so spotify
-```
-
-The path **MUST** be the absolute one. If it's not, the hack will not work.
-
-Now you can freely manage your Spotify client. Always use `class` to manage the 
-window. For example:
-
-```ini
-windowrulev2 = tile, class:^(Spotify)$
-windowrulev2 = workspace 9, class:^(Spotify)$
-```
-
-Pick your poison. 
-
 ## Matrix/Element
 
 [Fractal](https://wiki.gnome.org/Apps/Fractal) is a Matrix client written in GTK4.


### PR DESCRIPTION
There are some warnings about Spotify not respecting window rules in the docs.

https://github.com/hyprwm/hyprland-wiki/blob/b8de59bf08eec5f1d8103e16744b749ff4315b93/pages/Useful%20Utilities/App-Clients.md?plain=1#L16-L17

As it turns out, Spotify now follows the window rules, e.g., opening in its designated workspace, etc. So, these lines are not needed anymore.