### PR TITLE
Nvidia: Add tips to fixing suspend issues

### DIFF
--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -104,3 +104,11 @@ options nvidia NVreg_RegistryDwords="PowerMizerEnable=0x1; PerfLevelSrc=0x2222; 
 ```
 
 Reboot your computer and it should be working.
+
+## Fixing suspend/wakeup issues
+
+Enable the services `nvidia-suspend.service`, `nvidia-hibernate.service` and `nvidia-resume.service`, they will be started by systemd when needed.
+
+Add `nvidia.NVreg_PreserveVideoMemoryAllocations=1` to your kernel parameters if you don't have it already.
+
+{{< hint type=important >}} Suspend functions are currently broken on `nvidia-open-dkms` [due to a bug](https://github.com/NVIDIA/open-gpu-kernel-modules/issues/472), so make sure you're on `nvidia-dkms`. {{< /hint >}}

--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -112,3 +112,16 @@ Enable the services `nvidia-suspend.service`, `nvidia-hibernate.service` and `nv
 Add `nvidia.NVreg_PreserveVideoMemoryAllocations=1` to your kernel parameters if you don't have it already.
 
 {{< hint type=important >}} Suspend functions are currently broken on `nvidia-open-dkms` [due to a bug](https://github.com/NVIDIA/open-gpu-kernel-modules/issues/472), so make sure you're on `nvidia-dkms`. {{< /hint >}}
+
+For Nix users, the equivalent of the above is
+```nix
+# configuration.nix
+
+boot.kernelParams = [ "nvidia.NVreg_PreserveVideoMemoryAllocations=1" ];
+
+hardware.nvidia.powerManagement.enabled = true
+
+# Making sure to use the proprietary drivers until the issue above is fixed upstream
+hardware.nvidia.open = false 
+
+```


### PR DESCRIPTION
First PR ever, so here we go:

Nvidia's proprietary drivers include some systemd services to aid with suspend/hibernate and they aren't enabled by default in any of the distros I've seen, and their userspace driver only restores essential memory on wakeup, leading to graphical corruption and crashes, unless their driver is loaded with a specific parameter.