### PR TITLE
Remove unnecessary optimization from FAQ

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -244,9 +244,6 @@ It's heavily advised to use `full` regardless of anything.
 
 **_Useful Optimizations_**:
 
-* `decoration:blur:new_optimizations = true`, to use new optimizations for
-   blurring.
-
 * `decoration:blur = false` and `decoration:drop_shadow = false` to disable
    fancy but battery hungry effects.
 

--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -244,7 +244,7 @@ It's heavily advised to use `full` regardless of anything.
 
 **_Useful Optimizations_**:
 
-* `decoration:blur_new_optimizations = true`, to use new optimizations for
+* `decoration:blur:new_optimizations = true`, to use new optimizations for
    blurring.
 
 * `decoration:blur = false` and `decoration:drop_shadow = false` to disable


### PR DESCRIPTION
The `new_optimizations` field was incorrectly nested on the FAQ page.