### PR TITLE
Added FAQ item about TLP causing stutter on Intel

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -291,3 +291,6 @@ set `MOD` and `KEY` to desired values.
 By pressing the selected combo you will enter a mode where hyprland ignores your keybinds and passes them on to the vm.
 
 Then, pressing `SUPER + Escape` will leave that mode.
+
+# Low FPS/stutter/FPS drops on intel iGPU with TLP (mainly laptops)
+The TLP defaults are rather agressive, setting `INTEL_GPU_MIN_FREQ_ON_AC` and/or `INTEL_GPU_MIN_FREQ_ON_BAT` in `/etc/tlp.conf` to something slightly higer (e.g. to 500 from 300) will reduce stutter significantly or in the best case remove it completly.

--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -292,5 +292,6 @@ By pressing the selected combo you will enter a mode where hyprland ignores your
 
 Then, pressing `SUPER + Escape` will leave that mode.
 
-# Low FPS/stutter/FPS drops on intel iGPU with TLP (mainly laptops)
-The TLP defaults are rather agressive, setting `INTEL_GPU_MIN_FREQ_ON_AC` and/or `INTEL_GPU_MIN_FREQ_ON_BAT` in `/etc/tlp.conf` to something slightly higer (e.g. to 500 from 300) will reduce stutter significantly or, in the best case, remove it completly.
+# Low FPS/stutter/FPS drops on Intel iGPU with TLP (mainly laptops)
+
+The TLP defaults are rather aggressive, setting `INTEL_GPU_MIN_FREQ_ON_AC` and/or `INTEL_GPU_MIN_FREQ_ON_BAT` in `/etc/tlp.conf` to something slightly higher (e.g. to 500 from 300) will reduce stutter significantly or, in the best case, remove it completely.

--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -293,4 +293,4 @@ By pressing the selected combo you will enter a mode where hyprland ignores your
 Then, pressing `SUPER + Escape` will leave that mode.
 
 # Low FPS/stutter/FPS drops on intel iGPU with TLP (mainly laptops)
-The TLP defaults are rather agressive, setting `INTEL_GPU_MIN_FREQ_ON_AC` and/or `INTEL_GPU_MIN_FREQ_ON_BAT` in `/etc/tlp.conf` to something slightly higer (e.g. to 500 from 300) will reduce stutter significantly or in the best case remove it completly.
+The TLP defaults are rather agressive, setting `INTEL_GPU_MIN_FREQ_ON_AC` and/or `INTEL_GPU_MIN_FREQ_ON_BAT` in `/etc/tlp.conf` to something slightly higer (e.g. to 500 from 300) will reduce stutter significantly or, in the best case, remove it completly.


### PR DESCRIPTION
 The default TLP settings caused a lot of stutter and FPS drops when animations ran. It dropped to under 30 FPS from 60 on all animations. 

This was solved by increasing the minimum GPU frequency specified in TLP. I did some tests, it doesn´t seem to have any worse power consumption as the GPU goes into some deeper power-saving when idle anyway, but animations now run perfectly smooth at 60 FPS (which is the refresh rate of my Panel). 

And as it took me a while to figure it out I thought adding it to the FAQ, which I read like 5 times would be worth it. 