### PR TITLE
Hyprland on NixOS: Fix link to Home Manager page

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -97,4 +97,4 @@ in {
 
 ## Fixing problems with themes
 
-If your themes for mouse cursor, icons or windows don't load correctly, see the relevant section in [Hyprland on Home Manager](./Hyprland-on-Home-Manager).
+If your themes for mouse cursor, icons or windows don't load correctly, see the relevant section in [Hyprland on Home Manager](./Hyprland-on-Home-Manager.md).


### PR DESCRIPTION
The link currently leads to a directory named "Hyprland on Home Manager" instead of the markdown file named as such. Added .md to the link to fix this.