### PR TITLE
Fixes link to Hyprland on Home Manager page (in Hyprland on NixOS page)

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -97,4 +97,4 @@ in {
 
 ## Fixing problems with themes
 
-If your themes for mouse cursor, icons or windows don't load correctly, see the relevant section in [Hyprland on Home Manager](./Hyprland-on-Home-Manager).
+If your themes for mouse cursor, icons or windows don't load correctly, see the relevant section in [Hyprland on Home Manager](../Hyprland-on-Home-Manager).


### PR DESCRIPTION
The link to the [Hyprland on Home Manager](https://wiki.hyprland.org/Nix/Hyprland-on-Home-Manager/) page in the [Hyprland on NixOS](https://wiki.hyprland.org/Nix/Hyprland-on-NixOS/) page is incorrectly resolving to `https://wiki.hyprland.org/Nix/Hyprland-on-NixOS/Hyprland-on-Home-Manager` 

This changes it so that it correctly resolves to `https://wiki.hyprland.org/Nix/Hyprland-on-Home-Manager`