### PR TITLE
For discussion, NO MERGE : Dispatcher v2 API 1st proposition

### DIFF
--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -30,6 +30,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `orgroup` | When moving a client, performs different directionnal move : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client. |
 | `out` | Move out of a group but keeps group flag active. |
 | `prev` or `next` | Select previous or next element in a sequence. |
+| `reset` | Used to exit a `Submap` |
 | `resizeparams` | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
 | `stack` | Move to the stack `top` or `bottom`. |
 | `submapname` | A name for a submap. |
@@ -47,7 +48,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | ---------- | ----------- | ------ |
 | compositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | `none` |
 | compositorReloadRenderer | Forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | `none` |
-| compositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> | [m:] opt:`true`|`false`|`toggle` |
+| compositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> | `[m:]` opt:(`true`\|`false`\|`toggle`) |
 
 ## Execute and submap
 | Dispatcher | Description | Params |
@@ -59,15 +60,15 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
-| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` ([`ws:workspace` \| `m:monitor` ]) opt:`nofocus`\|`keepfocus` |
-| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` ([`prev`\|`next`]) opt:`ingroup` |
-| clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` `[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
+| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
+| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` ([`ws:workspace`] \| [`m:monitor` ]) opt:(`nofocus`\|`keepfocus`) |
+| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [(`prev`\|`next`)] opt:(`ingroup`) |
+| clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
 
 ## Client groups
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` `[direction]` opt:(`in`\|`out`\|`toggle`) |
+| clientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` dir:`[direction]` opt:(`in`\|`out`\|`toggle`) |
 | clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`out`) |
 | clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:(`unlock`\|`lock`\|`toggle`) |
@@ -86,11 +87,11 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:(`ignore`) |
-| clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
+| clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`fake`\|`togglefake`) |
 | clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
-| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` `stack` |
+| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` [(`bottom`\|`top`)] |
 | clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
 
 ## Cursor 
@@ -102,8 +103,8 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Focus
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump`|
-| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` opt:`[direction]` |
+| focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`)|
+| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` dir:`[direction]` |
 | focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:`urgent`\|`last`\|`urgentorlast` |
 | focusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
 | focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`prev`\|`next`] |

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -5,6 +5,9 @@
 Please keep in mind some layout-specific dispatchers will be listed in the
 layout pages (See the sidebar).
 
+Dispatchers actions are : Exec, Exit, Close, Cycle, Move, Reload, Rename, Send, Set, Swap. <sub>Discontinued: alter, bring, center, change, deny, force, kill, lock (unlock), pass, pin, resize</sub>.
+Dispatchers ames are not case sensitive and uppercase is only use for easier reading.
+
 
 
 # Parameter explanation
@@ -21,8 +24,8 @@ layout pages (See the sidebar).
 
 | Param type | Description |
 | ---------- | ----------- |
-| [client] |  Identifies a client. If none is specified then it defaults to `current` of `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
-| stack | `top` or `bottom` |
+| `[client]` |  Identifies a client. If none is specified then it defaults to `current` of `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
+| `stack` | `top` or `bottom` |
 | jump or nojump | When moving a client to the edge of the monitor, allow or not jumping to next monitor in a given direction | 
 | nofocus or keepfocus | Do not focus or do keep focus on a client or workspace that was sent elsewhere |
 | m:monitor | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
@@ -33,30 +36,31 @@ layout pages (See the sidebar).
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
 | ws:workspace | Specified workspace by ... |
 | ignore | |
+| `none` | No optional parameter required or taken. | 
 
 # List of Dispatchers
 
 ## Compositor
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| CompositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | none |
-| CompositorReloadRenderer |  | forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | none |
+| CompositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | `none` |
+| CompositorReloadRenderer | Forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | `none` |
 | CompositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> [m:] opt:`true`|`false`|`toggle`
 
 ## Execute and submap
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| Exec | Executes a shell command | `command` (supports rules, see [below]({{< relref "#executing-with-rules" >}})) |
+| Exec | Executes a shell command. (supports rules, see [below]({{< relref "#executing with rules" >}})) | `command`  |
 | Execr | Executes a raw shell command (will not append any additional envvars like `exec` does, does not support rules) | `command` |
 | SetSubmap | Change the current mapping group. See [Submaps](../Binds/#submaps) | `reset` or name |
 
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| ClientMoveDir | Moves a client in workspace or to a monitor following direction \| direction or `mon:` and a monitor. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:nofocus\|dofocus opt:orgroup|
-| ClientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [ws:workspace \| m:monitor ] opt:nofocus\|dofocus |
-| ClientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [prev\|next] opt:`ingroup` |
-| ClientSwapDir | Swaps the client with another client in the given direction. <sub>Deprecates: swapwindow</sub> | `[client]` opt:`nojump`\|`dojump` opt:`nofocus`\|`dofocus` |
+| ClientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:`nojump`\|`jump` opt:`orgroup` |
+| ClientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [`ws:workspace` \| `m:monitor` ] opt:`nofocus`\|`keepfocus` |
+| ClientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [`prev`\|`next`] opt:`ingroup` |
+| ClientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump` opt:`nofocus`\|`keepfocus` |
 
 ## Client groups
 | Dispatcher | Description | Params |
@@ -79,7 +83,6 @@ layout pages (See the sidebar).
 ## Client states
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-
 | ClientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`noreserved`\|`reserved` |
 | ClientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
 | ClientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`fake`\|`togglefake` |
@@ -100,7 +103,7 @@ layout pages (See the sidebar).
 | FocusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump`|
 | FocusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` opt:`[direction]` |
 | FocusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | `[client]`\|`[ws:]`\|`[m:]` opt:`urgent`\|`last`\|`urgentorlast` |
-| FocusGroupCycle | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
+| FocusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
 | FocusMoveHistory |  Switch focus from current to previously focused client. Note `newer` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`older`\|`newer`] |
 
 ## Workspace

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -14,7 +14,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 
 
 # Parameter explanation
-
+<sub>Discontinued: `silent` </sub>
 | Param type | Description |
 | ---------- | ----------- |
 | `[client]` |  Identifies a client. If none is specified then it defaults to `current` or `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
@@ -25,7 +25,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `command` | A shell command to execute |
 | `false` or `true`  | Boolean of 0 and 1 |
 | `floatvalue` | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
-| `ignore` | Ignore a state, a flag, a lock or a reserved area. |
+| `ignore` or `enforce` | Ignore or enforce a state, a flag, a lock or a reserved area. |
 | `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. <sub>Deprecates: silent</sub> |
 | `nojump` or `jump` | When moving to the edge of the monitor, allow or not jumping to next monitor in a given direction. | 
 | `none` | No optional parameter required or taken. | 
@@ -38,7 +38,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `submapname` | A name for a submap. |
 | `toggle` | Toggle between boolean values. |
 | `togglefake` | Toogle between values `fullscreen` and `fake`. |
-| `toggleignore` | Toggle between `ignore` state and `lock` state | 
+| `toggleignore` | Toggle between states, like `ignore` state and `enforce` state | 
 | `workspaceopt` | See below FIXME:AT. |
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
 
@@ -61,7 +61,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> Note `orgroup` : When moving a client, performs differently : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client.| `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
+| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
 | clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [(`ws:workspace` \| `m:monitor`)] opt:(`nofocus`\|`keepfocus`) |
 | clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` opt:(`prev`\|`next`) opt:(`ingroup`) |
 | clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
@@ -73,7 +73,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetGroup | Toggles the client into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`out`) |
 | clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:(`unlock`\|`lock`\|`toggle`) |
-| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:(`unlock`\|`lock`\|`toggle`\|`ignore`) |
+| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:(`unlock`\|`lock`\|`toggle`\|`ignore`\|`enforce`\|`toggleignore`) |
 
 ## Client interaction
 | Dispatcher | Description | Params |
@@ -105,7 +105,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`)|
-| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext, changegroupactive</sub> | `[client]` opt:`(prev\|next)` opt:(`orgroup`) |
+| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext, changegroupactive</sub> | `[client]` opt:`(prev\|next)` opt:(`orgroup`\|`onlygroup`) |
 | focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:`urgent`\|`last`\|`urgentorlast` |
 | focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | opt:(`prev`\|`next`) |
 
@@ -135,15 +135,51 @@ bind = MOD,KEY,exec,sleep 1 && hyprctl dispatch compositorSetDpms off
 Hyprland allows you to make a group from the current active clients with the `clientSetGroup` bind dispatcher.
 
 A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the focus to the next one in the tabbed “group” with the `focusMoveCycle opt:(orgroup\|onlygroup)` bind dispatcher.
+The parameter `orgroup` will move the focus on next client if curent client is not in a group or if it's alone NOTE: check about alone. 
+While the opt:`onlygroup` parameter will not change focus if selected client is not in a group with an other member.
+
+To create a group, you must first enable a client to be a group on it's own with `clientSetGroup`.
+Once you have a group, you can move an other client adjacent to it by a `clientMoveGroupDir opt:in`.
+You can also get a selected client out of a group with `clientMoveGroupDir opt:out`.
+If you want to move a client in or out of a group, you can use the opt:`toggle` and it will act accordingly to the case of `in` or `out`.
+
+```txt
+bind = SUPERCTRL, G, clientSetGroup, opt:toggle
+
+bind = SUPERCTRLSHIFT, LEFT, clientMoveGroupDir, left opt:in
+bind = SUPERCTRLSHIFT, RIGHT, clientMoveGroupDir, right opt:in
+bind = SUPERCTRLSHIFT, UP, clientMoveGroupDir, up opt:in
+bind = SUPERCTRLSHIFT, DOWN, clientMoveGroupDir, down opt:in
+# Move a client inside a group, do nothing if there's no group in that direction
+```
+
+To change the focus to an other member of a group in a cycle without cycling all other clients not in the group on the workspace.
+
+```txt
+bind = SUPERCTRL, TAB, focusMoveCycle opt:next opt:onlygroup
+bind = SUPERCTRLSHIFT, TAB, focusMoveCycle opt:prev opt:onlygroup
+# Will only cycle focus on clients if they are in a groupe and they are not alone
+```
 
 The new group’s border colors are configurable with the appropriate `col.` settings in the `group` config section.
 
 You can lock a group with the `clientSetGrouplock` dispatcher in order to stop new client from entering this group.
 In addition, the `clientSetGrouplocks` dispatcher can be used to toggle an independent global group lock that will prevent
-new client from entering any groups, regardless of their local group lock stat.
+new client from entering (FIXME:or leaving?) any groups, regardless of their local group lock stat.
+
+```txt
+bind = SUPERCTRLSHIFT, L, clientSetGrouplock, opt:toggle
+#Stop new client from entering this focused group
+bind = SUPERCTRLSHIFTALT, L, clientSetGrouplocks, opt:ignoretoggle
+#Ignore all group locks while this is set to ignore without disabling the individual group locks.
+bind = SUPERCTRLSHIFTALT, F12, clientSetGrouplocks, opt:toggle
+#Disable or enable locks on all groups
+```
 
 You can prevent a client from being added to group or becoming a group with the `clientSetDenyGroup` dispatcher.
 `clientMoveDir opt:orgroup` will behave like `clientMoveDir` but move the whole group in a given direction.
+
+For `clientMoveDir [direction] opt:orgroup` : When moving a client, it performs differently : if the focused client is in a group, it will move out of it; if the client is not in group, will move in an adjacent group if it exist; if neither worked, will just move the client in `[direction]`.
 
 # Workspaces
 
@@ -193,13 +229,15 @@ You can define multiple named special workspaces as `special:wsname`, but the am
 
 For example, to move a client/application to a special workspace you can use the following syntax:
 
-```
+```txt
 bind = SUPER, C, clientMoveTo, special
-bind = SUPERALT, C, workspaceSetVisible, special opt:toggle
+bind = SUPERALT, C, workspaceSetVisible, special, opt:toggle
 #The above syntax will move the active client to a special workspace upon pressing 'SUPER'+'C'.
 #To see the hidden client you can use the `opt:toggle` dispatcher mentioned above.
-bind = SUPER, H, clientMoveTo, special:hidden opt:nofocus # Do not keep focus on the client, sends it silently
-bind = SUPERALT, H, workspaceSetVisible, special:hidden opt:toggle
+bind = SUPER, S, clientMoveTo, special:secret, opt:nofocus 
+bind = SUPERALT, S, workspaceSetVisible, special:secret, opt:toggle
+#Same as previous, but 'SUPER'+'S' and do not keep focus on the client, sends it silently to special:secret workspace.
+#To see the hidden client on the special workspace named secret.
 ```
 
 # Workspace options
@@ -223,4 +261,5 @@ bind = mod, key, exec, [rules...] command
 For example:
 ```
 bind = SUPER, E, exec, [ws:2 nofocus;float;noanim] kitty
+#Will launch kitty on workspace 2 without giving it focus, so if you are on ws:1, you will stay there.
 ```

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -6,11 +6,14 @@ Please keep in mind some layout-specific dispatchers will be listed in the
 layout pages (See the sidebar).
 
 Dispatchers have been reviewed and renamed for version 2 of it's API. Depricated and discontinued functions will still work until further end of life notice.
+Version 1 and 2 of the API will be supported by `hyprctl dispatch @dispatcherfunction`.
 
-Dispatchers actions are : `Exec`, `Exit`, `Close`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
+New dispatchers actions are : `Exec`, `Exit`, `Close`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
 <sub>Discontinued: alter, bring, center, change, cycle, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
 
-Dispatchers names are not case sensitive and uppercase is only use for easier reading.
+Dispatcher's names are not case sensitive and uppercase is only use for easier reading. 
+
+Dispatcher's name may only be seperated by a space when called from `hyprctl` and must remain unseparated for `bind`.
 
 
 # Parameter explanation
@@ -45,7 +48,7 @@ TODO: Decide if `opt:` should be mandatory for parameters so it's easier to pars
 | `togglefake` | Toogle between values `fullscreen` and `fake`. |
 | `toggleignore` | Toggle between states, like `ignore` state and `enforce` state | 
 | `unlock` or `lock` | Unlocked or locked state |
-| `workspaceopt` | See below FIXME:AT. |
+| `workspaceopt` | See below FIXME:link. |
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
 
 # List of Dispatchers

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -19,6 +19,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `[client]` |  Identifies a client. If none is specified then it defaults to `current` or `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
 | `[direction]` | One of `l` `r` `u` `d` or `left` `right` `up` `down`. |
 | `[m:monitor]` | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
+| `[corner]` | Designates a position on a client for cursor movement. Of : `topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`. |
 | `[ws:]` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
 | `command` | A shell command to execute |
 | `false` or `true`  | Boolean of 0 and 1 |
@@ -37,7 +38,6 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `toggle` | Toggle between boolean values. |
 | `togglefake` | Toogle between values `fullscreen` and `fake`. |
 | `toggleignore` | Toggle between `ignore` state and `lock` state | 
-| `topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center` | Designates a position on a client for cursor movement. |
 | `workspaceopt` | See below FIXME:AT. |
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
 
@@ -61,8 +61,8 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
-| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` ([`ws:workspace`] \| [`m:monitor` ]) opt:(`nofocus`\|`keepfocus`) |
-| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [(`prev`\|`next`)] opt:(`ingroup`) |
+| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [(`ws:workspace` \| `m:monitor`)] opt:(`nofocus`\|`keepfocus`) |
+| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` opt:(`prev`\|`next`) opt:(`ingroup`) |
 | clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
 
 ## Client groups
@@ -79,7 +79,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | ---------- | ----------- | ------ |
 | clientClose | Closes the client. <sub>Deprecates: killactive, closewindow</sub> | `[client]` |
 | clientSendGlobalkey | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) <sub>Deprecates: global </sub> | `[client]` `key` |
-| clientSendPassKey | Passes the key (with mods) to a specified client. Can be used as a workaround to global keybinds not working on Wayland. <sub>Deprecates: pass </sub> | `[client]` `key` |
+| clientSendPassKey | Passes the key (with mods) to a specified client. Can be used as a workaround to global keybinds not working on Wayland. <sub>Deprecates: pass </sub> | `[client]` |
 | clientSetPos | Moves a selected window. <sub>Deprecates: moveactive, movewindowpixel</sub> | `[client]` `resizeparams` |
 | clientSetSize | Resizes the client geometry. <sub>Deprecates: resizeactive, resizewindowpixel</sub> | `[client]` `resizeparams` |
 
@@ -91,14 +91,14 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`fake`\|`togglefake`) |
 | clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
-| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` [(`bottom`\|`top`)] |
+| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` opt:(`bottom`\|`top`) |
 | clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
 
 ## Cursor 
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | cursorMovePos | Moves the cursor to a specified position relative to total geometry or specified monitor. Note : may not have implemented monitor selection. <sub>Deprecates: movecursor</sub> | `[m:]` `x` `y` |
-| cursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` opt:(`topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`) |
+| cursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` opt:`[corner]` |
 
 ## Focus
 | Dispatcher | Description | Params |

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -5,76 +5,114 @@
 Please keep in mind some layout-specific dispatchers will be listed in the
 layout pages (See the sidebar).
 
+
+
 # Parameter explanation
 
 | Param type | Description |
 | ---------- | ----------- |
-| window | a window. Any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled` |
+| client | a wayland client, otherwise known as window. Any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled` |
 | workspace | see below. |
 | direction | `l` `r` `u` `d` left right up down |
 | monitor | One of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
 | resizeparams | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
 | floatvalue | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
 | workspaceopt | see below. |
-| zheight | `top` or `bottom` |
+
+| Param type | Description |
+| ---------- | ----------- |
+| [client] |  Identifies a client. If none is specified then it defaults to `current` of `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
+| stack | `top` or `bottom` |
+| jump or nojump | When moving a client to the edge of the monitor, allow or not jumping to next monitor in a given direction | 
+| nofocus or keepfocus | Do not focus or do keep focus on a client or workspace that was sent elsewhere |
+| m:monitor | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
+| orgroup | Behaves as `moveintogroup` if there is a group in the given direction. Behaves as `moveoutofgroup` if there is no group in the given direction relative to the active group. Otherwise behaves like `movewindow`|
+| `out` | Mouve out of a group but keeps group flag active |
+| toggle | Toggle between boolean values |
+| togglefake | Toogle between boolean values `fullscreen` and `fake` |
+| `wsname` | A workspace name : `id name`, e.g. `2 work` |
+| ws:workspace | Specified workspace by ... |
+| ignore | |
 
 # List of Dispatchers
 
+## Compositor
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| exec | executes a shell command | command (supports rules, see [below]({{< relref "#executing-with-rules" >}})) |
-| execr | executes a raw shell command (will not append any additional envvars like `exec` does, does not support rules) | command |
-| pass | passes the key (with mods) to a specified window. Can be used as a workaround to global keybinds not working on Wayland. | window |
-| killactive | closes (not kills) the active window | none |
-| closewindow | closes a specified window | window |
-| workspace | changes the workspace | workspace |
-| movetoworkspace | moves the focused window to a workspace | workspace OR `workspace,window` for a specific window |
-| movetoworkspacesilent | same as above, but doesnt switch to the workspace | workspace OR `workspace,window` for a specific window |
-| togglefloating | toggles the current window's floating state | left empty / `active` for current, or `window` for a specific window |
-| fullscreen | toggles the focused window's fullscreen state | 0 - fullscreen (takes your entire screen), 1 - maximize (keeps gaps and bar(s)) |
-| fakefullscreen | toggles the focused window's internal fullscreen state without altering the geometry | none |
-| dpms | sets all monitors' DPMS status. Do not use with a keybind directly. | `on`, `off`, or `toggle`. For specific monitor add monitor name after a space |
-| pin | pins a window (i.e. show it on all workspaces) *note: floating only* | left empty / `active` for current, or `window` for a specific window |
-| movefocus | moves the focus in a direction | direction |
-| movewindow | moves the active window in a direction or to a monitor | direction or `mon:` and a monitor |
-| swapwindow | swaps the active window with another window in the given direction | direction |
-| centerwindow | center the active window *note: floating only* | none (for monitor center) or 1 (to respect monitor reserved area) |
-| resizeactive | resizes the active window | resizeparams |
-| moveactive | moves the active window | resizeparams |
-| resizewindowpixel | resizes a selected window | `resizeparams,window`, e.g. `100 100,^(kitty)$` |
-| movewindowpixel | moves a selected window | `resizeparams,window` |
-| cyclenext | focuses the next window on a workspace | none (for next) or `prev` (for previous) |
-| swapnext | swaps the focused window with the next window on a workspace | none (for next) or `prev` (for previous) |
-| focuswindow | focuses the first window matching | window |
-| focusmonitor | focuses a monitor | monitor |
-| splitratio | changes the split ratio | floatvalue |
-| toggleopaque | toggles the current window to always be opaque. Will override the `opaque` window rules. | none |
-| movecursortocorner | moves the cursor to the corner of the active window | direction, 0 - 3, bottom left - 0, bottom right - 1, top right - 2, top left - 3 |
-| movecursor | moves the cursor to a specified position | `x y` |
-| workspaceopt | toggles a workspace option for the active workspace. | workspaceopt |
-| renameworkspace | rename a workspace | `id name`, e.g. `2 work` |
-| exit | exits the compositor with no questions asked. | none |
-| forcerendererreload | forces the renderer to reload all resources and outputs | none |
-| movecurrentworkspacetomonitor | Moves the active workspace to a monitor | monitor |
-| moveworkspacetomonitor | Moves a workspace to a monitor | workspace and a monitor separated by a space |
-| swapactiveworkspaces | Swaps the active workspaces between two monitors | two monitors separated by a space |
-| bringactivetotop | *Deprecated* in favor of alterzorder.  Brings the current window to the top of the stack | none |
-| alterzorder | Modify the window stack order of the active or specified window. Note: this cannot be used to move a floating window behind a tiled one. | zheight[,window] |
-| togglespecialworkspace | toggles a special workspace on/off | none (for the first) or name for named (name has to be a special workspace's name) |
-| focusurgentorlast | Focuses the urgent window or the last window | none |
-| togglegroup | toggles the current active window into a group | none |
-| changegroupactive | switches to the next window in a group. | b - back, f - forward, or index start at 1  |
-| focuscurrentorlast | Switch focus from current to previously focused window | none |
-| lockgroups | Locks the groups (all groups will not accept new windows) | `lock` for locking, `unlock` for unlocking, `toggle` for toggle |
-| lockactivegroup | Lock the focused group (the current group will not accept new windows or be moved to other groups) | `lock` for locking, `unlock` for unlocking, `toggle` for toggle |
-| moveintogroup | Moves the active window into a group in a specified direction. No-op if there is no group in the specified direction. | direction |
-| moveoutofgroup | Moves the active window out of a group. No-op if not in a group | none |
-| movewindoworgroup | Behaves as `moveintogroup` if there is a group in the given direction. Behaves as `moveoutofgroup` if there is no group in the given direction relative to the active group. Otherwise behaves like `movewindow`. | direction |
-| movegroupwindow | Swaps the active window with the next or previous in a group | `b` for back, anything else for forward |
-| denywindowfromgroup | Prohibit the active window from becoming or being inserted into group | `on`, `off` or, `toggle` |
-| setignoregrouplock | Temporarily enable or disable binds:ignore_group_lock | `on`, `off`, or `toggle` |
-| global | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) | name |
-| submap | Change the current mapping group. See [Submaps](../Binds/#submaps) | `reset` or name |
+| CompositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | none |
+| CompositorReloadRenderer |  | forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | none |
+| CompositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> [m:] opt:`true`|`false`|`toggle`
+
+## Execute and submap
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| Exec | Executes a shell command | `command` (supports rules, see [below]({{< relref "#executing-with-rules" >}})) |
+| Execr | Executes a raw shell command (will not append any additional envvars like `exec` does, does not support rules) | `command` |
+| SetSubmap | Change the current mapping group. See [Submaps](../Binds/#submaps) | `reset` or name |
+
+## Client movement
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| ClientMoveDir | Moves a client in workspace or to a monitor following direction \| direction or `mon:` and a monitor. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:nofocus\|dofocus opt:orgroup|
+| ClientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [ws:workspace \| m:monitor ] opt:nofocus\|dofocus |
+| ClientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [prev\|next] opt:`ingroup` |
+| ClientSwapDir | Swaps the client with another client in the given direction. <sub>Deprecates: swapwindow</sub> | `[client]` opt:`nojump`\|`dojump` opt:`nofocus`\|`dofocus` |
+
+## Client groups
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| ClientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` `[direction]` opt:`in`\|`out`\|`toggle` |
+| ClientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| ClientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`out` |
+| ClientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:`unlock`\|`lock`\|`toggle` |
+| ClientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:`unlock`\|`lock`\|`toggle`\|`ignore` |
+
+## Client interaction
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| ClientClose | Closes the client. <sub>Deprecates: killactive, closewindow</sub> | `[client]` |
+| ClientSendGlobalkey | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) <sub>Deprecates: global </sub> | `[client]` `key` |
+| ClientSendPassKey | Passes the key (with mods) to a specified client. Can be used as a workaround to global keybinds not working on Wayland. <sub>Deprecates: pass </sub> | `[client]` `key` |
+| ClientSetPos | Moves a selected window. <sub>Deprecates: moveactive, movewindowpixel</sub> | `[client]` `resizeparams` |
+| ClientSetSize | Resizes the client geometry. <sub>Deprecates: resizeactive, resizewindowpixel</sub> | `[client]` `resizeparams` |
+
+## Client states
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+
+| ClientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`noreserved`\|`reserved` |
+| ClientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
+| ClientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`fake`\|`togglefake` |
+| ClientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| ClientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| ClientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | [client] `stack` |
+| ClientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
+
+## Cursor 
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| CursorMovePos | Moves the cursor to a specified position relative to total geometry or specified monitor. Note : may not have implemented monitor selection. <sub>Deprecates: movecursor</sub> | `[m:]` `x` `y` |
+| CursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` [`topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`] |
+
+## Focus
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| FocusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump`|
+| FocusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` opt:`[direction]` |
+| FocusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | `[client]`\|`[ws:]`\|`[m:]` opt:`urgent`\|`last`\|`urgentorlast` |
+| FocusGroupCycle | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
+| FocusMoveHistory |  Switch focus from current to previously focused client. Note `newer` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`older`\|`newer`] |
+
+## Workspace
+| Dispatcher | Description | Params |
+| ---------- | ----------- | ------ |
+| WorkspaceMoveTo | Moves the a workspace to a monitor. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: movecurrentworkspacetomonitor,moveworkspacetomonitor</sub> | `[ws:]` `[m:]` |
+| WorkspaceRename | Rename a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
+| WorkspaceSetOpt | Toggles a workspace option a workspace. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
+| WorkspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:`true`\|`false`\|`toggle` |
+| WorkspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:`nofocus`\|`dofocus` |
+
+
 
 {{< hint type=warning >}}
 it is NOT recommended to set DPMS with a keybind directly, as it

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -7,8 +7,8 @@ layout pages (See the sidebar).
 
 Dispatchers have been reviewed and renamed for version 2 of it's API. Depricated and discontinued functions will still work until further end of life notice.
 
-Dispatchers actions are : `Exec`, `Exit`, `Close`, `Cycle`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
-<sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
+Dispatchers actions are : `Exec`, `Exit`, `Close`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
+<sub>Discontinued: alter, bring, center, change, cycle, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
 
 Dispatchers names are not case sensitive and uppercase is only use for easier reading.
 
@@ -29,7 +29,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. <sub>Deprecates: silent</sub> |
 | `nojump` or `jump` | When moving to the edge of the monitor, allow or not jumping to next monitor in a given direction. | 
 | `none` | No optional parameter required or taken. | 
-| `orgroup` | When moving a client, performs different directionnal move : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client. |
+| `orgroup` or `onlygroup` | Dispatcher will act differently, `orgroup` will have same action if focus is on a group or a client; `onlygroup` action will be performed only if focus is on a client in a group |
 | `out` | Move out of a group but keeps group flag active. |
 | `prev` or `next` | Select previous or next element in a sequence. |
 | `reset` | Used to exit a `Submap` |
@@ -61,7 +61,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
+| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> Note `orgroup` : When moving a client, performs differently : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client.| `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
 | clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [(`ws:workspace` \| `m:monitor`)] opt:(`nofocus`\|`keepfocus`) |
 | clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` opt:(`prev`\|`next`) opt:(`ingroup`) |
 | clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
@@ -134,7 +134,7 @@ bind = MOD,KEY,exec,sleep 1 && hyprctl dispatch compositorSetDpms off
 
 Hyprland allows you to make a group from the current active clients with the `clientSetGroup` bind dispatcher.
 
-A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the focus to the next one in the tabbed “group” with the `focusMoveCycle opt:orgroup` bind dispatcher.
+A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the focus to the next one in the tabbed “group” with the `focusMoveCycle opt:(orgroup\|onlygroup)` bind dispatcher.
 
 The new group’s border colors are configurable with the appropriate `col.` settings in the `group` config section.
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -5,9 +5,11 @@
 Please keep in mind some layout-specific dispatchers will be listed in the
 layout pages (See the sidebar).
 
-Dispatchers actions are : `Exec`, `Exit`, `Close`, `Cycle`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. <sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
-Dispatchers names are not case sensitive and uppercase is only use for easier reading.
+Dispatchers have been reviewed and renamed for version 2 of it's API. Depricated and discontinued functions will still work until further end of life notice.
 
+Dispatchers actions are : `Exec`, `Exit`, `Close`, `Cycle`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. <sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
+
+Dispatchers names are not case sensitive and uppercase is only use for easier reading.
 
 
 # Parameter explanation
@@ -20,25 +22,23 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `[ws:]` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
 | `command` | A shell command to execute |
 | `false` or `true`  | Boolean of 0 and 1 |
+| `floatvalue` | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
 | `ignore` | Ignore a state, a flag, a lock or a reserved area. |
 | `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. |
 | `nojump` or `jump` | When moving to the edge of the monitor, allow or not jumping to next monitor in a given direction. | 
 | `none` | No optional parameter required or taken. | 
 | `orgroup` | When moving a client, performs different directionnal move : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client. |
 | `out` | Move out of a group but keeps group flag active. |
-| `prev` or `next` | Select previous or next element in a sequence. Boolean of 0 and 1 |
-| `stack` | `top` or `bottom` |
+| `prev` or `next` | Select previous or next element in a sequence. |
+| `resizeparams` | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
+| `stack` | Move to the stack `top` or `bottom`. |
 | `submapname` | A name for a submap. |
 | `toggle` | Toggle between boolean values. |
-| `togglefake` | Toogle between boolean values `fullscreen` and `fake`. |
-| `toggleignore` | Toggle between ignore state and lock state | 
+| `togglefake` | Toogle between values `fullscreen` and `fake`. |
+| `toggleignore` | Toggle between `ignore` state and `lock` state | 
 | `topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center` | Designates a position on a client for cursor movement. |
+| `workspaceopt` | See below FIXME:AT. |
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
-| floatvalue | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
-| resizeparams | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
-| workspaceopt | see below. |
-
-
 
 # List of Dispatchers
 
@@ -47,7 +47,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | ---------- | ----------- | ------ |
 | compositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | `none` |
 | compositorReloadRenderer | Forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | `none` |
-| compositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> [m:] opt:`true`|`false`|`toggle`
+| compositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> | [m:] opt:`true`|`false`|`toggle` |
 
 ## Execute and submap
 | Dispatcher | Description | Params |
@@ -59,19 +59,19 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:`nojump`\|`jump` opt:`orgroup` |
-| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [`ws:workspace` \| `m:monitor` ] opt:`nofocus`\|`keepfocus` |
-| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [`prev`\|`next`] opt:`ingroup` |
-| clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump` opt:`nofocus`\|`keepfocus` |
+| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
+| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` ([`ws:workspace` \| `m:monitor` ]) opt:`nofocus`\|`keepfocus` |
+| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` ([`prev`\|`next`]) opt:`ingroup` |
+| clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` `[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
 
 ## Client groups
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` `[direction]` opt:`in`\|`out`\|`toggle` |
-| clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
-| clientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`out` |
-| clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:`unlock`\|`lock`\|`toggle` |
-| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:`unlock`\|`lock`\|`toggle`\|`ignore` |
+| clientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` `[direction]` opt:(`in`\|`out`\|`toggle`) |
+| clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
+| clientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`out`) |
+| clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:(`unlock`\|`lock`\|`toggle`) |
+| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:(`unlock`\|`lock`\|`toggle`\|`ignore`) |
 
 ## Client interaction
 | Dispatcher | Description | Params |
@@ -85,11 +85,11 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Client states
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`ignore` |
+| clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:(`ignore`) |
 | clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
-| clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`fake`\|`togglefake` |
-| clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
-| clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`fake`\|`togglefake`) |
+| clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
+| clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` `stack` |
 | clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
 
@@ -97,7 +97,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | cursorMovePos | Moves the cursor to a specified position relative to total geometry or specified monitor. Note : may not have implemented monitor selection. <sub>Deprecates: movecursor</sub> | `[m:]` `x` `y` |
-| cursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` [`topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`] |
+| cursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` opt:(`topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`) |
 
 ## Focus
 | Dispatcher | Description | Params |

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -5,8 +5,8 @@
 Please keep in mind some layout-specific dispatchers will be listed in the
 layout pages (See the sidebar).
 
-Dispatchers actions are : Exec, Exit, Close, Cycle, Move, Reload, Rename, Send, Set, Swap. <sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
-Dispatchers ames are not case sensitive and uppercase is only use for easier reading.
+Dispatchers actions are : `Exec`, `Exit`, `Close`, `Cycle`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. <sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
+Dispatchers names are not case sensitive and uppercase is only use for easier reading.
 
 
 
@@ -14,35 +14,29 @@ Dispatchers ames are not case sensitive and uppercase is only use for easier rea
 
 | Param type | Description |
 | ---------- | ----------- |
-| client | a wayland client, otherwise known as window. Any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled` |
-| workspace | see below. |
-| direction | `l` `r` `u` `d` left right up down |
-| monitor | One of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
-| resizeparams | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
-| floatvalue | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
-| workspaceopt | see below. |
-
-| Param type | Description |
-| ---------- | ----------- |
-| `[client]` |  Identifies a client. If none is specified then it defaults to `current` of `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
+| `[client]` |  Identifies a client. If none is specified then it defaults to `current` or `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
+| `[direction]` | One of `l` `r` `u` `d` or `left` `right` `up` `down`. |
+| `[m:monitor]` | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
+| `[ws:]` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
+| `command` | A shell command to execute |
+| `false` or `true`  | Boolean of 0 and 1 |
+| `ignore` | Ignore a state, a flag, a lock or a reserved area. |
+| `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. |
+| `nojump` or `jump` | When moving to the edge of the monitor, allow or not jumping to next monitor in a given direction. | 
+| `none` | No optional parameter required or taken. | 
+| `orgroup` | When moving a client, performs different directionnal move : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client. |
+| `out` | Move out of a group but keeps group flag active. |
+| `prev` or `next` | Select previous or next element in a sequence. Boolean of 0 and 1 |
 | `stack` | `top` or `bottom` |
-| `nojump` or `jump` | When moving a client to the edge of the monitor, allow or not jumping to next monitor in a given direction | 
-| `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere |
-| `m:monitor` | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
-| `orgroup` | Behaves as `moveintogroup` if there is a group in the given direction. Behaves as `moveoutofgroup` if there is no group in the given direction relative to the active group. Otherwise behaves like `movewindow`|
-| `out` | Mouve out of a group but keeps group flag active. |
+| `submapname` | A name for a submap. |
 | `toggle` | Toggle between boolean values. |
 | `togglefake` | Toogle between boolean values `fullscreen` and `fake`. |
-| `wsname` | A workspace name : `id name`, e.g. `2 work` |
-| `ws:` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
-| `ignore` | Ignore a state, a flag, a lock or a reserved area. |
 | `toggleignore` | Toggle between ignore state and lock state | 
-| `none` | No optional parameter required or taken. | 
-| `submapname` | A name for a submap. |
-| `command` | A shell command to execute |
-| [topleft\|topright\|bottomleft\|bottomright\|center] | |
-| `prev` or `next` | Select previous or next element in a sequence. Boolean of 0 and 1 |
-| `false` or `true`  | Boolean of 0 and 1 |
+| `topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center` | Designates a position on a client for cursor movement. |
+| `wsname` | A workspace name : `id name`, e.g. `2 work` |
+| floatvalue | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
+| resizeparams | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
+| workspaceopt | see below. |
 
 
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -106,8 +106,8 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`)|
 | focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` dir:`[direction]` |
 | focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:`urgent`\|`last`\|`urgentorlast` |
-| focusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
-| focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`prev`\|`next`] |
+| focusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`(prev\|next)` |
+| focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | opt:(`prev`\|`next`) |
 
 ## Workspace
 | Dispatcher | Description | Params |
@@ -115,8 +115,8 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | workspaceMoveTo | Moves the a workspace to a monitor. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: movecurrentworkspacetomonitor,moveworkspacetomonitor</sub> | `[ws:]` `[m:]` |
 | workspaceRename | Renames a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
 | workspaceSetOpt | Sets workspace option. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
-| workspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:`true`\|`false`\|`toggle` |
-| workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:`nofocus`\|`dofocus` |
+| workspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:(`true`\|`false`\|`toggle`) |
+| workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:(`nofocus`\|`dofocus`) |
 
 
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -14,23 +14,28 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 
 
 # Parameter explanation
-<sub>Discontinued: `silent` </sub>
+TODO: Decide if `opt:` should be mandatory for parameters so it's easier to parse them or if we should just go away with it.
+
+<sub>Discontinued: `b`, `f`, `silent`, `zheight` </sub>
 | Param type | Description |
 | ---------- | ----------- |
 | `[client]` |  Identifies a client. If none is specified then it defaults to `current` or `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
+| `[corner]` | Designates a position on a client for cursor movement. Of : `topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`. |
 | `[direction]` | One of `l` `r` `u` `d` or `left` `right` `up` `down`. |
 | `[m:monitor]` | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
-| `[corner]` | Designates a position on a client for cursor movement. Of : `topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`. |
 | `[ws:]` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
+| `active` or `current` | Depending on the function, will be the selected or focused : `client`, `group`, `monitor` or `workspace`. |
 | `command` | A shell command to execute |
+| `fake` | A state for clients to be in a fullscreen mode without having a whole monitor. |
 | `false` or `true`  | Boolean of 0 and 1 |
 | `floatvalue` | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
 | `ignore` or `enforce` | Ignore or enforce a state, a flag, a lock or a reserved area. |
+| `in` or `out` | Move in of a group or out of a group but keeps group flag active. |
 | `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. <sub>Deprecates: silent</sub> |
 | `nojump` or `jump` | When moving to the edge of the monitor, allow or not jumping to next monitor in a given direction. | 
 | `none` | No optional parameter required or taken. | 
+| `off` or `on`  | Same as `false` or `true` |
 | `orgroup` or `onlygroup` | Dispatcher will act differently, `orgroup` will have same action if focus is on a group or a client; `onlygroup` action will be performed only if focus is on a client in a group |
-| `out` | Move out of a group but keeps group flag active. |
 | `prev` or `next` | Select previous or next element in a sequence. |
 | `reset` | Used to exit a `Submap` |
 | `resizeparams` | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |
@@ -39,6 +44,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `toggle` | Toggle between boolean values. |
 | `togglefake` | Toogle between values `fullscreen` and `fake`. |
 | `toggleignore` | Toggle between states, like `ignore` state and `enforce` state | 
+| `unlock` or `lock` | Unlocked or locked state |
 | `workspaceopt` | See below FIXME:AT. |
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
 
@@ -61,7 +67,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:`orgroup` |
+| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:(`orgroup`) |
 | clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [(`ws:workspace` \| `m:monitor`)] opt:(`nofocus`\|`keepfocus`) |
 | clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` opt:(`prev`\|`next`) opt:(`ingroup`) |
 | clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
@@ -92,7 +98,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`fake`\|`togglefake`) |
 | clientSetOpaque | Toggles the client to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
-| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` opt:(`bottom`\|`top`) |
+| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates: alterzorder, bringactivetotop</sub> | `[client]` opt:(`bottom`\|`top`) |
 | clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
 
 ## Cursor 
@@ -116,7 +122,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | workspaceRename | Renames a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
 | workspaceSetOpt | Sets workspace option. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
 | workspaceSetVisible | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:(`true`\|`false`\|`toggle`) |
-| workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:(`nofocus`\|`dofocus`) |
+| workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | (`[ws:]`\|`[m:]`) (`[ws:]`\|`[m:]`) opt:(`nofocus`\|`dofocus`) |
 
 
 
@@ -134,13 +140,18 @@ bind = MOD,KEY,exec,sleep 1 && hyprctl dispatch compositorSetDpms off
 
 Hyprland allows you to make a group from the current active clients with the `clientSetGroup` bind dispatcher.
 
-A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the focus to the next one in the tabbed “group” with the `focusMoveCycle opt:(orgroup\|onlygroup)` bind dispatcher.
-The parameter `orgroup` will move the focus on next client if curent client is not in a group or if it's alone NOTE: check about alone. 
+A group is like i3wm’s “tabbed” container. 
+
+It takes the space of one client, and you can change the focus to the next one in the tabbed “group” with the `focusMoveCycle opt:(orgroup\|onlygroup)` bind dispatcher.
+The parameter `orgroup` will move the focus on next client if curent client is not in a group or if it's alone. NOTE: check about alone. 
 While the opt:`onlygroup` parameter will not change focus if selected client is not in a group with an other member.
 
 To create a group, you must first enable a client to be a group on it's own with `clientSetGroup`.
+
 Once you have a group, you can move an other client adjacent to it by a `clientMoveGroupDir opt:in`.
+
 You can also get a selected client out of a group with `clientMoveGroupDir opt:out`.
+
 If you want to move a client in or out of a group, you can use the opt:`toggle` and it will act accordingly to the case of `in` or `out`.
 
 ```txt
@@ -153,17 +164,19 @@ bind = SUPERCTRLSHIFT, DOWN, clientMoveGroupDir, down opt:in
 # Move a client inside a group, do nothing if there's no group in that direction
 ```
 
-To change the focus to an other member of a group in a cycle without cycling all other clients not in the group on the workspace.
+To change the focus to an other member of a group in a cycle. Without cycling all other clients not in the group on the workspace.
 
 ```txt
 bind = SUPERCTRL, TAB, focusMoveCycle opt:next opt:onlygroup
 bind = SUPERCTRLSHIFT, TAB, focusMoveCycle opt:prev opt:onlygroup
-# Will only cycle focus on clients if they are in a groupe and they are not alone
+#Will only cycle focus on clients if they are in a groupe and they are not alone
+#If you don't care about group only cycling, use opt:orgroup and it will cycle to clients outside of the group after it reached it's last one. 
 ```
 
 The new group’s border colors are configurable with the appropriate `col.` settings in the `group` config section.
 
 You can lock a group with the `clientSetGrouplock` dispatcher in order to stop new client from entering this group.
+
 In addition, the `clientSetGrouplocks` dispatcher can be used to toggle an independent global group lock that will prevent
 new client from entering (FIXME:or leaving?) any groups, regardless of their local group lock stat.
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -7,7 +7,8 @@ layout pages (See the sidebar).
 
 Dispatchers have been reviewed and renamed for version 2 of it's API. Depricated and discontinued functions will still work until further end of life notice.
 
-Dispatchers actions are : `Exec`, `Exit`, `Close`, `Cycle`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. <sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
+Dispatchers actions are : `Exec`, `Exit`, `Close`, `Cycle`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
+<sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
 
 Dispatchers names are not case sensitive and uppercase is only use for easier reading.
 
@@ -104,9 +105,8 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`)|
-| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` dir:`[direction]` |
+| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext, changegroupactive</sub> | `[client]` opt:`(prev\|next)` opt:(`orgroup`) |
 | focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:`urgent`\|`last`\|`urgentorlast` |
-| focusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`(prev\|next)` |
 | focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | opt:(`prev`\|`next`) |
 
 ## Workspace
@@ -134,7 +134,7 @@ bind = MOD,KEY,exec,sleep 1 && hyprctl dispatch compositorSetDpms off
 
 Hyprland allows you to make a group from the current active clients with the `clientSetGroup` bind dispatcher.
 
-A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the clien to the next one in the tabbed “group” with the `focusCycleGroup` bind dispatcher.
+A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the focus to the next one in the tabbed “group” with the `focusMoveCycle opt:orgroup` bind dispatcher.
 
 The new group’s border colors are configurable with the appropriate `col.` settings in the `group` config section.
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -25,7 +25,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | `false` or `true`  | Boolean of 0 and 1 |
 | `floatvalue` | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
 | `ignore` | Ignore a state, a flag, a lock or a reserved area. |
-| `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. |
+| `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. <sub>Deprecates: silent</sub> |
 | `nojump` or `jump` | When moving to the edge of the monitor, allow or not jumping to next monitor in a given direction. | 
 | `none` | No optional parameter required or taken. | 
 | `orgroup` | When moving a client, performs different directionnal move : if in a group, will move out of it; if not in group, will move in; if neither, will just move the client. |
@@ -70,7 +70,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | ---------- | ----------- | ------ |
 | clientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` dir:`[direction]` opt:(`in`\|`out`\|`toggle`) |
 | clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
-| clientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`out`) |
+| clientSetGroup | Toggles the client into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`out`) |
 | clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:(`unlock`\|`lock`\|`toggle`) |
 | clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:(`unlock`\|`lock`\|`toggle`\|`ignore`) |
 
@@ -80,7 +80,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | clientClose | Closes the client. <sub>Deprecates: killactive, closewindow</sub> | `[client]` |
 | clientSendGlobalkey | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) <sub>Deprecates: global </sub> | `[client]` `key` |
 | clientSendPassKey | Passes the key (with mods) to a specified client. Can be used as a workaround to global keybinds not working on Wayland. <sub>Deprecates: pass </sub> | `[client]` |
-| clientSetPos | Moves a selected window. <sub>Deprecates: moveactive, movewindowpixel</sub> | `[client]` `resizeparams` |
+| clientSetPos | Moves a selected client. <sub>Deprecates: moveactive, movewindowpixel</sub> | `[client]` `resizeparams` |
 | clientSetSize | Resizes the client geometry. <sub>Deprecates: resizeactive, resizewindowpixel</sub> | `[client]` `resizeparams` |
 
 ## Client states
@@ -89,7 +89,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:(`ignore`) |
 | clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`fake`\|`togglefake`) |
-| clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
+| clientSetOpaque | Toggles the client to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` opt:(`bottom`\|`top`) |
 | clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
@@ -115,7 +115,7 @@ Dispatchers names are not case sensitive and uppercase is only use for easier re
 | workspaceMoveTo | Moves the a workspace to a monitor. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: movecurrentworkspacetomonitor,moveworkspacetomonitor</sub> | `[ws:]` `[m:]` |
 | workspaceRename | Renames a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
 | workspaceSetOpt | Sets workspace option. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
-| workspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:(`true`\|`false`\|`toggle`) |
+| workspaceSetVisible | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:(`true`\|`false`\|`toggle`) |
 | workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:(`nofocus`\|`dofocus`) |
 
 
@@ -125,25 +125,25 @@ it is NOT recommended to set DPMS with a keybind directly, as it
 might cause undefined behavior. Instead, consider something like
 
 ```ini
-bind = MOD,KEY,exec,sleep 1 && hyprctl dispatch dpms off
+bind = MOD,KEY,exec,sleep 1 && hyprctl dispatch compositorSetDpms off
 ```
 
 {{< /hint >}}
 
-## Grouped (tabbed) windows
+## Grouped (tabbed) clients
 
-Hyprland allows you to make a group from the current active window with the `togglegroup` bind dispatcher.
+Hyprland allows you to make a group from the current active clients with the `clientSetGroup` bind dispatcher.
 
-A group is like i3wm’s “tabbed” container. It takes the space of one window, and you can change the window to the next one in the tabbed “group” with the `changegroupactive` bind dispatcher.
+A group is like i3wm’s “tabbed” container. It takes the space of one client, and you can change the clien to the next one in the tabbed “group” with the `focusCycleGroup` bind dispatcher.
 
 The new group’s border colors are configurable with the appropriate `col.` settings in the `group` config section.
 
-You can lock a group with the `lockactivegroup` dispatcher in order to stop new window from entering this group.
-In addition, the `lockgroups` dispatcher can be used to toggle an independent global group lock that will prevent
-new window from entering any groups, regardless of their local group lock stat.
+You can lock a group with the `clientSetGrouplock` dispatcher in order to stop new client from entering this group.
+In addition, the `clientSetGrouplocks` dispatcher can be used to toggle an independent global group lock that will prevent
+new client from entering any groups, regardless of their local group lock stat.
 
-You can prevent a window from being added to group or becoming a group with the `denywindowfromgroup` dispatcher.
-`movewindoworgroup` will behave like `movewindow` if current active window or window in direction has this property set.
+You can prevent a client from being added to group or becoming a group with the `clientSetDenyGroup` dispatcher.
+`clientMoveDir opt:orgroup` will behave like `clientMoveDir` but move the whole group in a given direction.
 
 # Workspaces
 
@@ -169,7 +169,7 @@ You have eight choices:
 
 {{< hint type=warning >}}
 `special` is supported ONLY on
-`movetoworkspace` and `movetoworkspacesilent`. Any other dispatcher will result in undocumented behavior.
+`clientMoveTo` and `clientMoveTo opt:(nofocus|keepfocus)`. Any other dispatcher will result in undocumented behavior.
 {{< /hint >}}
 
 {{< hint type=important >}}
@@ -185,31 +185,35 @@ A special workspace is what is called a "scratchpad" in some other places. A
 workspace that you can toggle on/off on any monitor.
 
 {{< hint >}}
-You cannot have floating windows in a Special workspace. Making a window floating
+You cannot have floating clients in a Special workspace. Making a client floating with `clientSetFloating`
 will send it to the currently active _real_ workspace.
 
-You can define multiple named special workspaces, but the amount of those is limited to 97 at a time.
+You can define multiple named special workspaces as `special:wsname`, but the amount of those is limited to 97 at a time.
 {{< /hint >}}
 
-For example, to move a window/application to a special workspace you can use the following syntax:
+For example, to move a client/application to a special workspace you can use the following syntax:
 
 ```
-bind = SUPER, C, movetoworkspace, special
-#The above syntax will move the window to a special workspace upon pressing 'SUPER'+'C'.
-#To see the hidden window you can use the togglespecialworkspace dispatcher mentioned above.
+bind = SUPER, C, clientMoveTo, special
+bind = SUPERALT, C, workspaceSetVisible, special opt:toggle
+#The above syntax will move the active client to a special workspace upon pressing 'SUPER'+'C'.
+#To see the hidden client you can use the `opt:toggle` dispatcher mentioned above.
+bind = SUPER, H, clientMoveTo, special:hidden opt:nofocus # Do not keep focus on the client, sends it silently
+bind = SUPERALT, H, workspaceSetVisible, special:hidden opt:toggle
 ```
 
 # Workspace options
 
+Possible `workspaceopt` are :
 ```txt
-allfloat -> makes all new windows floating (also floats/unfloats windows on toggle)
-allpseudo -> makes all new windows pseudo (also pseudos/unpseudos on toggle)
+allfloat -> makes all new clients floating (also floats/unfloats clients on toggle)
+allpseudo -> makes all new clients pseudo (also pseudos/unpseudos on toggle) FIXME:DEFINE PSEUDO
 ```
 
 # Executing with rules
-The `exec` dispatcher supports adding rules. Please note some windows might work better, some
+The `exec` dispatcher supports adding rules. Please note some clients might work better, some
 worse. It records the PID of the spawned process and uses that. If your process e.g. forks and then
-the fork opens a window, this will not work.
+the fork opens a clients, this will not work.
 
 The syntax is:
 ```
@@ -218,5 +222,5 @@ bind = mod, key, exec, [rules...] command
 
 For example:
 ```
-bind = SUPER, E, exec, [workspace 2 silent;float;noanim] kitty
+bind = SUPER, E, exec, [ws:2 nofocus;float;noanim] kitty
 ```

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -5,7 +5,7 @@
 Please keep in mind some layout-specific dispatchers will be listed in the
 layout pages (See the sidebar).
 
-Dispatchers actions are : Exec, Exit, Close, Cycle, Move, Reload, Rename, Send, Set, Swap. <sub>Discontinued: alter, bring, center, change, deny, force, kill, lock (unlock), pass, pin, resize</sub>.
+Dispatchers actions are : Exec, Exit, Close, Cycle, Move, Reload, Rename, Send, Set, Swap. <sub>Discontinued: alter, bring, center, change, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
 Dispatchers ames are not case sensitive and uppercase is only use for easier reading.
 
 
@@ -37,83 +37,85 @@ Dispatchers ames are not case sensitive and uppercase is only use for easier rea
 | ws:workspace | Specified workspace by ... |
 | ignore | |
 | `none` | No optional parameter required or taken. | 
+| `submapname` | A name for a submap. |
+| `command` | A shell command to execute |
 
 # List of Dispatchers
 
 ## Compositor
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| CompositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | `none` |
-| CompositorReloadRenderer | Forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | `none` |
-| CompositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> [m:] opt:`true`|`false`|`toggle`
+| compositorExit | Exits the compositor with no questions asked. <sub>Deprecates: exit</sub> | `none` |
+| compositorReloadRenderer | Forces the renderer to reload all resources and outputs. <sub>Deprecates: forcerendererreload</sub> | `none` |
+| compositorSetDpms | Sets all monitors' DPMS status unless specific monitor specified. Do not use with a keybind directly. <sub>Deprecates: dpms</sub> [m:] opt:`true`|`false`|`toggle`
 
 ## Execute and submap
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| Exec | Executes a shell command. (supports rules, see [below]({{< relref "#executing with rules" >}})) | `command`  |
-| Execr | Executes a raw shell command (will not append any additional envvars like `exec` does, does not support rules) | `command` |
-| SetSubmap | Change the current mapping group. See [Submaps](../Binds/#submaps) | `reset` or name |
+| exec | Executes a shell command. (supports rules, see [below]({{< relref "#executing with rules" >}})) | `command`  |
+| execr | Executes a raw shell command (will not append any additional envvars like `exec` does, does not support rules) | `command` |
+| setSubmap | Change the current mapping group. See [Submaps](../Binds/#submaps) | `reset` or `submapname` |
 
 ## Client movement
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| ClientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:`nojump`\|`jump` opt:`orgroup` |
-| ClientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [`ws:workspace` \| `m:monitor` ] opt:`nofocus`\|`keepfocus` |
-| ClientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [`prev`\|`next`] opt:`ingroup` |
-| ClientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump` opt:`nofocus`\|`keepfocus` |
+| clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` `[direction]` opt:`nojump`\|`jump` opt:`orgroup` |
+| clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [`ws:workspace` \| `m:monitor` ] opt:`nofocus`\|`keepfocus` |
+| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` [`prev`\|`next`] opt:`ingroup` |
+| clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump` opt:`nofocus`\|`keepfocus` |
 
 ## Client groups
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| ClientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` `[direction]` opt:`in`\|`out`\|`toggle` |
-| ClientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
-| ClientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`out` |
-| ClientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:`unlock`\|`lock`\|`toggle` |
-| ClientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:`unlock`\|`lock`\|`toggle`\|`ignore` |
+| clientMoveGroupDir | Moves a client into a group or out in a specified direction. No-op if there is no group in the specified direction. <sub>Deprecates: moveintogroup, moveoutofgroup</sub> | `[client]` `[direction]` opt:`in`\|`out`\|`toggle` |
+| clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| clientSetGroup | Toggles the client window into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`out` |
+| clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:`unlock`\|`lock`\|`toggle` |
+| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:`unlock`\|`lock`\|`toggle`\|`ignore` |
 
 ## Client interaction
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| ClientClose | Closes the client. <sub>Deprecates: killactive, closewindow</sub> | `[client]` |
-| ClientSendGlobalkey | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) <sub>Deprecates: global </sub> | `[client]` `key` |
-| ClientSendPassKey | Passes the key (with mods) to a specified client. Can be used as a workaround to global keybinds not working on Wayland. <sub>Deprecates: pass </sub> | `[client]` `key` |
-| ClientSetPos | Moves a selected window. <sub>Deprecates: moveactive, movewindowpixel</sub> | `[client]` `resizeparams` |
-| ClientSetSize | Resizes the client geometry. <sub>Deprecates: resizeactive, resizewindowpixel</sub> | `[client]` `resizeparams` |
+| clientClose | Closes the client. <sub>Deprecates: killactive, closewindow</sub> | `[client]` |
+| clientSendGlobalkey | Executes a Global Shortcut using the GlobalShortcuts portal. See [here](../Binds/#global-keybinds) <sub>Deprecates: global </sub> | `[client]` `key` |
+| clientSendPassKey | Passes the key (with mods) to a specified client. Can be used as a workaround to global keybinds not working on Wayland. <sub>Deprecates: pass </sub> | `[client]` `key` |
+| clientSetPos | Moves a selected window. <sub>Deprecates: moveactive, movewindowpixel</sub> | `[client]` `resizeparams` |
+| clientSetSize | Resizes the client geometry. <sub>Deprecates: resizeactive, resizewindowpixel</sub> | `[client]` `resizeparams` |
 
 ## Client states
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| ClientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`noreserved`\|`reserved` |
-| ClientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
-| ClientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`fake`\|`togglefake` |
-| ClientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
-| ClientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
-| ClientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | [client] `stack` |
-| ClientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
+| clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`noreserved`\|`reserved` |
+| clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
+| clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`fake`\|`togglefake` |
+| clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
+| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | [client] `stack` |
+| clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
 
 ## Cursor 
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| CursorMovePos | Moves the cursor to a specified position relative to total geometry or specified monitor. Note : may not have implemented monitor selection. <sub>Deprecates: movecursor</sub> | `[m:]` `x` `y` |
-| CursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` [`topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`] |
+| cursorMovePos | Moves the cursor to a specified position relative to total geometry or specified monitor. Note : may not have implemented monitor selection. <sub>Deprecates: movecursor</sub> | `[m:]` `x` `y` |
+| cursorMoveTo | Moves the cursor to the corner of a client. <sub>Deprecates: movecursortocorner</sub> | `[client]` [`topleft`\|`topright`\|`bottomleft`\|`bottomright`\|`center`] |
 
 ## Focus
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| FocusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump`|
-| FocusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` opt:`[direction]` |
-| FocusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | `[client]`\|`[ws:]`\|`[m:]` opt:`urgent`\|`last`\|`urgentorlast` |
-| FocusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
-| FocusMoveHistory |  Switch focus from current to previously focused client. Note `newer` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`older`\|`newer`] |
+| focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump`|
+| focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` opt:`[direction]` |
+| focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | `[client]`\|`[ws:]`\|`[m:]` opt:`urgent`\|`last`\|`urgentorlast` |
+| focusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
+| focusMoveHistory |  Switch focus from current to previously focused client. Note `newer` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`older`\|`newer`] |
 
 ## Workspace
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| WorkspaceMoveTo | Moves the a workspace to a monitor. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: movecurrentworkspacetomonitor,moveworkspacetomonitor</sub> | `[ws:]` `[m:]` |
-| WorkspaceRename | Rename a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
-| WorkspaceSetOpt | Toggles a workspace option a workspace. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
-| WorkspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:`true`\|`false`\|`toggle` |
-| WorkspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:`nofocus`\|`dofocus` |
+| workspaceMoveTo | Moves the a workspace to a monitor. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: movecurrentworkspacetomonitor,moveworkspacetomonitor</sub> | `[ws:]` `[m:]` |
+| workspaceRename | Rename a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
+| workspaceSetOpt | Toggles a workspace option a workspace. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
+| workspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:`true`\|`false`\|`toggle` |
+| workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:`nofocus`\|`dofocus` |
 
 
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -8,7 +8,7 @@ layout pages (See the sidebar).
 Dispatchers have been reviewed and renamed for version 2 of it's API. Depricated and discontinued functions will still work until further end of life notice.
 Version 1 and 2 of the API will be supported by `hyprctl dispatch @dispatcherfunction`.
 
-New dispatchers actions are : `Exec`, `Exit`, `Close`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
+Dispatchers actions for revised API are : `Exec`, `Exit`, `Close`, `Move`, `Reload`, `Rename`, `Send`, `Set` and `Swap`. 
 <sub>Discontinued: alter, bring, center, change, cycle, deny, force, focus, kill, lock (unlock), pass, pin, resize</sub>.
 
 Dispatcher's names are not case sensitive and uppercase is only use for easier reading. 
@@ -72,7 +72,7 @@ TODO: Decide if `opt:` should be mandatory for parameters so it's easier to pars
 | ---------- | ----------- | ------ |
 | clientMoveDir | Moves a client or a group of clients in workspace following `direction`. Can jump to next monitor unless specified. <sub>Deprecates : movewindow, movewindoworgroup</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`jump`) opt:(`orgroup`) |
 | clientMoveTo | Moves a client to a workspace or monitor. <sub>Deprecates: movetoworkspace, movetoworkspacesilent</sub> | `[client]` [(`ws:workspace` \| `m:monitor`)] opt:(`nofocus`\|`keepfocus`) |
-| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` opt:(`prev`\|`next`) opt:(`ingroup`) |
+| clientSwapCycle | Swaps the client with the next client on a workspace or in a group. <sub>Deprecates: swapnext, movegroupwindow </sub> | `[client]` opt:(`prev`\|`next`) opt:(`onlygroup`\|`orgroup`) |
 | clientSwapDir | Swaps the client with another client in the given `direction`. Will swap with client on a adjacent monitor if option specified. Focus can be stay at originap place or be keept by client that currently has it.<sub>Deprecates: swapwindow</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`) opt:(`nofocus`\|`keepfocus`) |
 
 ## Client groups
@@ -82,7 +82,7 @@ TODO: Decide if `opt:` should be mandatory for parameters so it's easier to pars
 | clientSetDenyGroup | Prohibit a client from becoming or being inserted into group. <sub>Deprecates: denywindowfromgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetGroup | Toggles the client into a group state. <sub>Deprecates: togglegroup, moveoutofgroup</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`out`) |
 | clientSetGrouplock | Lock the group of a client (the current group will not accept new clients or be moved to other groups) <sub>Deprecates: lockactivegroup</sub> | `[client]` opt:(`unlock`\|`lock`\|`toggle`) |
-| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:(`unlock`\|`lock`\|`toggle`\|`ignore`\|`enforce`\|`toggleignore`) |
+| clientSetGrouplocks | Locks all the groups (all groups will not accept new clients). <sub>Deprecates: lockgroups,setignoregrouplock</sub> | opt:(`unlock`\|`lock`\|`toggle`) opt:(`ignore`\|`enforce`\|`toggleignore`) |
 
 ## Client interaction
 | Dispatcher | Description | Params |
@@ -98,7 +98,7 @@ TODO: Decide if `opt:` should be mandatory for parameters so it's easier to pars
 | ---------- | ----------- | ------ |
 | clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:(`ignore`) |
 | clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:(`true`\|`false`\|`toggle`) |
-| clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`\|`fake`\|`togglefake`) |
+| clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) opt:(`true`\|`fake`\|`togglefake`) |
 | clientSetOpaque | Toggles the client to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:(`true`\|`false`\|`toggle`) |
 | clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates: alterzorder, bringactivetotop</sub> | `[client]` opt:(`bottom`\|`top`) |
@@ -115,7 +115,7 @@ TODO: Decide if `opt:` should be mandatory for parameters so it's easier to pars
 | ---------- | ----------- | ------ |
 | focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` dir:`[direction]` opt:(`nojump`\|`dojump`)|
 | focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext, changegroupactive</sub> | `[client]` opt:`(prev\|next)` opt:(`orgroup`\|`onlygroup`) |
-| focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:`urgent`\|`last`\|`urgentorlast` |
+| focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:(`urgent`\|`last`\|`urgentorlast`) |
 | focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | opt:(`prev`\|`next`) |
 
 ## Workspace

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -26,19 +26,25 @@ Dispatchers ames are not case sensitive and uppercase is only use for easier rea
 | ---------- | ----------- |
 | `[client]` |  Identifies a client. If none is specified then it defaults to `current` of `focused`. If specified, can be any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled`  |
 | `stack` | `top` or `bottom` |
-| jump or nojump | When moving a client to the edge of the monitor, allow or not jumping to next monitor in a given direction | 
-| nofocus or keepfocus | Do not focus or do keep focus on a client or workspace that was sent elsewhere |
-| m:monitor | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
-| orgroup | Behaves as `moveintogroup` if there is a group in the given direction. Behaves as `moveoutofgroup` if there is no group in the given direction relative to the active group. Otherwise behaves like `movewindow`|
-| `out` | Mouve out of a group but keeps group flag active |
-| toggle | Toggle between boolean values |
-| togglefake | Toogle between boolean values `fullscreen` and `fake` |
+| `nojump` or `jump` | When moving a client to the edge of the monitor, allow or not jumping to next monitor in a given direction | 
+| `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere |
+| `m:monitor` | Specified monitor by one of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
+| `orgroup` | Behaves as `moveintogroup` if there is a group in the given direction. Behaves as `moveoutofgroup` if there is no group in the given direction relative to the active group. Otherwise behaves like `movewindow`|
+| `out` | Mouve out of a group but keeps group flag active. |
+| `toggle` | Toggle between boolean values. |
+| `togglefake` | Toogle between boolean values `fullscreen` and `fake`. |
 | `wsname` | A workspace name : `id name`, e.g. `2 work` |
-| ws:workspace | Specified workspace by ... |
-| ignore | |
+| `ws:` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
+| `ignore` | Ignore a state, a flag, a lock or a reserved area. |
+| `toggleignore` | Toggle between ignore state and lock state | 
 | `none` | No optional parameter required or taken. | 
 | `submapname` | A name for a submap. |
 | `command` | A shell command to execute |
+| [topleft\|topright\|bottomleft\|bottomright\|center] | |
+| `prev` or `next` | Select previous or next element in a sequence. Boolean of 0 and 1 |
+| `false` or `true`  | Boolean of 0 and 1 |
+
+
 
 # List of Dispatchers
 
@@ -85,12 +91,12 @@ Dispatchers ames are not case sensitive and uppercase is only use for easier rea
 ## Client states
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
-| clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`noreserved`\|`reserved` |
+| clientSetCentered | Centers the client on screen *note: floating only*. May or may not respect reserved monitor reserved area. <sub>Deprecates: centerwindow</sub> | `[client]` opt:`ignore` |
 | clientSetFloating | Sets the client's floating state. <sub>Deprecates: togglefloating</sub>  | `[client]` opt:`true`\|`false`\|`toggle` |
 | clientSetFullscreen | Sets the client's fullscreen state. A fake fullscreen will set internal fullscreen state without altering the geometry. <sub>Deprecates: fullscreen, fakefullscreen</sub> | `[client]` opt:`true`\|`false`\|`toggle`\|`fake`\|`togglefake` |
 | clientSetOpaque | Toggles the window to always be opaque. Will override the `opaque` window rules. <sub>Deprecates: toggleopaque</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
 | clientSetPin | pins a client (i.e. show it on all workspaces) *note: floating only* <sub>Deprecates: pin</sub> | `[client]` opt:`true`\|`false`\|`toggle` |
-| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | [client] `stack` |
+| clientSetStack | Modify the client stack order of the client. Note: this cannot be used to move a floating client behind a tiled one. <sub>Deprecates:alterzorder, bringactivetotop</sub> | `[client]` `stack` |
 | clientSetSplitRatio | Changes the split ratio of a client. <sub>Deprecates: splitratio</sub> | `[client]` `floatvalue` |
 
 ## Cursor 
@@ -104,16 +110,16 @@ Dispatchers ames are not case sensitive and uppercase is only use for easier rea
 | ---------- | ----------- | ------ |
 | focusMoveDir | Moves the focus in a direction to an other client. <sub>Deprecates: movefocus</sub> | `[client]` `[direction]` opt:`nojump`\|`dojump`|
 | focusMoveCycle | Set focuse on the next client on a workspace <sub>Deprecates: cyclenext</sub> | `[client]` opt:`[direction]` |
-| focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | `[client]`\|`[ws:]`\|`[m:]` opt:`urgent`\|`last`\|`urgentorlast` |
+| focusMoveTo | Set focuse on : the first matching client, on a workspace or on a monitor. Options works only if unspecified target for urgent client, last client, urgent or last client. <sub>Deprecates: focuswindow, workspace, focusmonitor,focusurgentorlast</sub> | (`[client]`\|`[ws:]`\|`[m:]`) opt:`urgent`\|`last`\|`urgentorlast` |
 | focusCycleGroup | Switches to the next client in a group. <sub>Deprecates: changegroupactive</sub> | `[client]` opt:`[prev\|next]` |
-| focusMoveHistory |  Switch focus from current to previously focused client. Note `newer` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`older`\|`newer`] |
+| focusMoveHistory |  Switch focus from current to previously focused client and forward to the original. Note `next` may not be implemented. <sub>Deprecates: focuscurrentorlast</sub> | [`prev`\|`next`] |
 
 ## Workspace
 | Dispatcher | Description | Params |
 | ---------- | ----------- | ------ |
 | workspaceMoveTo | Moves the a workspace to a monitor. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: movecurrentworkspacetomonitor,moveworkspacetomonitor</sub> | `[ws:]` `[m:]` |
-| workspaceRename | Rename a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
-| workspaceSetOpt | Toggles a workspace option a workspace. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
+| workspaceRename | Renames a workspace. <sub>Deprecates: renameworkspace</sub> | `[ws:]` `[wsname]` |
+| workspaceSetOpt | Sets workspace option. <sub>Deprecates: workspaceopt</sub> | `[ws:]` `[opt]` | 
 | workspaceSetSpecial | Toggles a special workspace on/off <sub>Deprecates: togglespecialworkspace</sub> | `[ws:]` opt:`true`\|`false`\|`toggle` |
 | workspaceSwap | Swaps workspaces between two monitors. Can specify specific workspaces or monitor to swap it's active workspace. Note: Currently can't reorder workspaces on a monitor. <sub>Deprecates: swapactiveworkspaces</sub> | `[ws:]`\|`[m:]` `[ws:]`\|`[m:]` opt:`nofocus`\|`dofocus` |
 

--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -29,9 +29,10 @@ TODO: Decide if `opt:` should be mandatory for parameters so it's easier to pars
 | `[ws:]` | Identifies a workspace by it's name. If none is specified then it defaults to `current` of `focused`. |
 | `active` or `current` | Depending on the function, will be the selected or focused : `client`, `group`, `monitor` or `workspace`. |
 | `command` | A shell command to execute |
-| `fake` | A state for clients to be in a fullscreen mode without having a whole monitor. |
+| `fake` and `fakefullscreen` | A state for clients to be in a fullscreen mode without having a whole monitor. |
 | `false` or `true`  | Boolean of 0 and 1 |
 | `floatvalue` | a relative float delta (e.g `-0.2` or `+0.2`) or `exact` followed by a the exact float value (e.g. `exact 0.5`) |
+| `full` and `fullscreen` | Fullscreen state for clients |
 | `ignore` or `enforce` | Ignore or enforce a state, a flag, a lock or a reserved area. |
 | `in` or `out` | Move in of a group or out of a group but keeps group flag active. |
 | `nofocus` or `keepfocus` | Do not focus or do keep focus on a client or workspace that was sent elsewhere. <sub>Deprecates: silent</sub> |
@@ -170,8 +171,8 @@ bind = SUPERCTRLSHIFT, DOWN, clientMoveGroupDir, down opt:in
 To change the focus to an other member of a group in a cycle. Without cycling all other clients not in the group on the workspace.
 
 ```txt
-bind = SUPERCTRL, TAB, focusMoveCycle opt:next opt:onlygroup
-bind = SUPERCTRLSHIFT, TAB, focusMoveCycle opt:prev opt:onlygroup
+bind = SUPERCTRL, TAB, focusMoveCycle, opt:next, opt:onlygroup
+bind = SUPERCTRLSHIFT, TAB, focusMoveCycle, opt:prev opt:onlygroup
 #Will only cycle focus on clients if they are in a groupe and they are not alone
 #If you don't care about group only cycling, use opt:orgroup and it will cycle to clients outside of the group after it reached it's last one. 
 ```


### PR DESCRIPTION
The current API of dispatcher is not optimal, it's not uniform, uses too many types of different actions and has poor predictability for function's name.

Left unchanged, it is a irritant to new user and will get worse with time if the complexity of hyprland keeps growing in a far future. Those changes can be postponed, but having a API revision after release 1.0 wouldn't be the best.

As no names where kept and thus no collision with previous API occurs, *this could be implemented without breaking anything*.

Old API could be discouraged and eventually be deprecated and removed after a notice and appropriate elapsed time.

The term `window` is deprecated in favor of `client` as Wayland namely use clients. However Wayland does interchange the term `window` and `client` a lot in it's documentation but it says this about it's [architecture](https://wayland.freedesktop.org/architecture.html) : "is how **clients** actually render under wayland", "the rendering happens in the **client**, and the **client** just sends a request to the compositor to indicate the region that was updated ", "the compositor receives generic Wayland buffers from the **clients**". _Could revert to windows if maintainers or users strongly wish for it_.

This proposition is an attempt to consolidate the wording used in the dispatcher's functions name with a naming convention that :
```
    1. would help understand what a function does without having to read it's description.
    2. be uniform
         2.1 for the type of action it performs
         2.2 for the subject of the action
         2.3 for the target of the action
         2.4 for the passing of arguments, mandatory and optional
```

All names are in a format of : `nounVerbVariation`.

The number of dispatchers action verbs went down from **22** to **9**.

Lots of param where defined. Params use the `opt:param` syntax, may or may not be kept depending on difficulty to implement. 

A few examples are added for groups and special workspace.

Discussed in [#3805 ](https://github.com/hyprwm/Hyprland/discussions/3805)

First proposition, please check for : 
1. if it makes any sens to change the API
2. coherence and logic
3. omissions
4. ease of use
5. efficiency
6. orthography and syntax after first 3 :) 

This is in **no way implemented in bind or hyprctl** and is used to illustrate how the API could be redesigned. 

Thanks for your time in pondering on how to make hyprland even greater and please add your comments. I did try to finish in a rush and may have made a few "oops". I'll try to squash the request, hope it works.

