### PR TITLE
binds: Remove inaccurate comment about case and clarify xkb keysym usage

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -33,8 +33,7 @@ _The dispatcher list can be found in [Dispatchers](../Dispatchers/#list-of-dispa
 
 See the
 [xkbcommon-keysyms.h header](https://github.com/xkbcommon/libxkbcommon/blob/master/include/xkbcommon/xkbcommon-keysyms.h)
-for all the keysyms. The name you should use is the one after `XKB_KEY_`,
-written in all lowercase.
+for all the keysyms. The name you should use is the segment after `XKB_KEY_`.
 
 If you are unsure of what your key's name is, you can
 use `xev` or `wev` to find that information.


### PR DESCRIPTION
Tangentially related to https://github.com/hyprwm/Hyprland/issues/4045. I was researching if anything had changed with regard to bindings and ran across this bit in the docs that is both unclear and seemingly inaccurate. This is my attempt to clarify what keysym names to use as well as fix the inaccuracy. 
