### PR TITLE
Fix typo in pages/Plugins/Development/Getting-Started.md

### DIFF
--- a/pages/Plugins/Development/Getting-Started.md
+++ b/pages/Plugins/Development/Getting-Started.md
@@ -102,7 +102,7 @@ In order to make your life easier, it's a good idea to work on a nested debug Hy
 
 Enter your Hyprland directory and run `make debug`
 
-Make a copy of your config in `~/.config/hypr` called `hyprlandd.conf`.
+Make a copy of your config in `~/.config/hypr` called `hyprland.conf`.
 
 Remove _all_ `exec=` or `exec-once=` directives from your config.
 


### PR DESCRIPTION
Just a small fix for a typo on line 105 ("hyprlandd.conf" instead of "hyprland.conf") to avoid any confusion. (not very important)