### PR TITLE
Update Home Manager Link on Home Manager.md

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -1,5 +1,5 @@
 For a list of available options, check the
-[Home Manager options](https://nix-community.github.io/home-manager/options.html#opt-wayland.windowManager.hyprland.enable).
+[Home Manager options](https://nix-community.github.io/home-manager/options.xhtml#opt-wayland.windowManager.hyprland.enable).
 
 {{< hint title=Note >}}
 


### PR DESCRIPTION
The link updated externally and the old one no longer goes to the correct place