### PR TITLE
Fix Gentoo XDPH installation instructions

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -76,18 +76,19 @@ Builds for Fedora 38 and additional packages are available in the [solopasha/hyp
 If you are on an older version of Fedora, you can also compile it yourself by following the instructions [here](https://github.com/hyprwm/Hyprland/discussions/284)
 {{< /tab >}}
 {{< tab "Gentoo*" >}}
-The hyprland and xdg-desktop-portal-hyprland packages are available in the main tree:
+The hyprland package is available in the main tree:
 
 ```sh
 emerge --ask gui-wm/hyprland
-emerge --ask gui-libs/xdg-desktop-portal-hyprland
 ```
 
-Additional packages like hyprland-plugins, hyprpaper and hyprpicker are available in the [GURU](https://wiki.gentoo.org/wiki/Project:GURU) overlay. Community-contributed scripts are also available in GURU as part of the hyprland-contrib package.
+Additional packages like xdg-desktop-portal-hyprland, hyprland-plugins, hyprpaper and hyprpicker are available in the [GURU](https://wiki.gentoo.org/wiki/Project:GURU) overlay. Community-contributed scripts are also available in GURU as part of the hyprland-contrib package.
 
 ```sh
 eselect repository enable guru
 emaint sync -r guru
+
+emerge --ask gui-libs/xdg-desktop-portal-hyprland
 emerge --ask gui-apps/hyprland-plugins
 emerge --ask gui-apps/hyprpaper
 emerge --ask gui-apps/hyprpicker


### PR DESCRIPTION

In #271, XDPH was marked as "in the main tree". But in fact XDPH is only available in GURU.

[XDPH in GURU repo](https://github.com/gentoo/guru/tree/master/gui-libs/xdg-desktop-portal-hyprland).
