### PR TITLE
Nixos nvidia, fix: powerManagement.enable instead of enabled

### DIFF
--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -87,7 +87,7 @@ For Nix users, the equivalent of the above is
 
 boot.kernelParams = [ "nvidia.NVreg_PreserveVideoMemoryAllocations=1" ];
 
-hardware.nvidia.powerManagement.enabled = true
+hardware.nvidia.powerManagement.enable = true
 
 # Making sure to use the proprietary drivers until the issue above is fixed upstream
 hardware.nvidia.open = false 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/bd645e8668ec6612439a9ee7e71f7eac4099d4f6/nixos/modules/hardware/video/nvidia.nix#L82