### PR TITLE
remove waybar wlr/workspaces patch

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -8,19 +8,6 @@ Waybar is a GTK status bar made specifically for wlroots compositors and
 supports Hyprland by default. To use it, it's recommended to use your distro's
 package.
 
-## Compiling Manually
-
-To compile manually:
-
-Clone the source, cd into it, then do:
-
-```bash
-sed -i -e 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
-meson --prefix=/usr --buildtype=plain --auto-features=enabled --wrap-mode=nodownload build
-meson configure -Dexperimental=true build
-sudo ninja -C build install
-```
-
 If you want to use the workspaces module, first, copy the configuration files from
 `/etc/xdg/waybar/` into `~/.config/waybar/`. Then, in `~/.config/waybar/config` replace
 all the references to `sway/workspaces` with `hyprland/workspaces`.


### PR DESCRIPTION
removes reference to `wlr/workspaces` patch since `hyprland/workspace` should probably be used, and if I remember it correctly the `wlr/workspaces` protocol doesn't even work anymore