### PR TITLE
fix bug caused by xwaylandvideobridge example configuration

### DIFF
--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -22,7 +22,11 @@ If your screensharing application is running under XWayland (like Discord, Skype
 The KDE-team has implemented a workaround for this called [xwaylandvideobridge](https://invent.kde.org/system/xwaylandvideobridge). You can use [this AUR package](https://aur.archlinux.org/packages/xwaylandvideobridge-bin) on ArchLinux.
 Note that Hyprland currently doesn't support the way it tries to hide the main window, so you will have to create some window-rules to achieve the same effect. See [this issue](https://invent.kde.org/system/xwaylandvideobridge/-/issues/1) for more information. For example:
 ```ini
+windowrulev2 = maxsize 1 1,class:^(xwaylandvideobridge)$
+windowrulev2 = noblur 1 1,class:^(xwaylandvideobridge)$
 windowrulev2 = opacity 0.0 override 0.0 override,class:^(xwaylandvideobridge)$
 windowrulev2 = noanim,class:^(xwaylandvideobridge)$
 windowrulev2 = noinitialfocus,class:^(xwaylandvideobridge)$
+windowrulev2 = maxsize 1 1,class:^(xwaylandvideobridge)$
+windowrulev2 = noblur,class:^(xwaylandvideobridge)$
 ```

--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -22,8 +22,6 @@ If your screensharing application is running under XWayland (like Discord, Skype
 The KDE-team has implemented a workaround for this called [xwaylandvideobridge](https://invent.kde.org/system/xwaylandvideobridge). You can use [this AUR package](https://aur.archlinux.org/packages/xwaylandvideobridge-bin) on ArchLinux.
 Note that Hyprland currently doesn't support the way it tries to hide the main window, so you will have to create some window-rules to achieve the same effect. See [this issue](https://invent.kde.org/system/xwaylandvideobridge/-/issues/1) for more information. For example:
 ```ini
-windowrulev2 = maxsize 1 1,class:^(xwaylandvideobridge)$
-windowrulev2 = noblur 1 1,class:^(xwaylandvideobridge)$
 windowrulev2 = opacity 0.0 override 0.0 override,class:^(xwaylandvideobridge)$
 windowrulev2 = noanim,class:^(xwaylandvideobridge)$
 windowrulev2 = noinitialfocus,class:^(xwaylandvideobridge)$

--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -24,6 +24,5 @@ Note that Hyprland currently doesn't support the way it tries to hide the main w
 ```ini
 windowrulev2 = opacity 0.0 override 0.0 override,class:^(xwaylandvideobridge)$
 windowrulev2 = noanim,class:^(xwaylandvideobridge)$
-windowrulev2 = nofocus,class:^(xwaylandvideobridge)$
 windowrulev2 = noinitialfocus,class:^(xwaylandvideobridge)$
 ```


### PR DESCRIPTION
The nofocus rule causes a disgusting behaviour when launching a program with rofi in the workspace where xwaylandvideobridge silently resides, causing it to launch in the last used workspace with an open window instead.