### PR TITLE
fix: missing instructions for copying wlroots and hyprctl

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -288,3 +288,5 @@ Now, of course, install manually.
 ```plain
 sudo cp ./build/Hyprland /usr/bin && sudo cp ./example/hyprland.desktop /usr/share/wayland-sessions
 ```
+
+Lastly, copy hyprctl and wlroots as mentioned [here](#manual-releases-linux-only)


### PR DESCRIPTION
There's no instruction to copy wlroots and hyprctl when building manually with flags. This add it.

I wanted to append the `sudo cp` command, but figured wlroots might change build directories.