### PR TITLE
Ranges formatted

### DIFF
--- a/pages/Configuring/Dwindle-Layout.md
+++ b/pages/Configuring/Dwindle-Layout.md
@@ -13,17 +13,17 @@ category name: `dwindle`
 
 | name | description | type | default |
 |---|---|---|---|
-| pseudotile | enable pseudotiling. Pseudotiled windows retain their floating size when tiled. | bool | false |
+| pseudotile | enable pseudotiling. Pseudotiled windows retain their floating size when tiled. [0/1/2] | bool | false |
 | force_split | 0 -> split follows mouse, 1 -> always split to the left (new = left or top) 2 -> always split to the right (new = right or bottom) | int | 0 |
 | preserve_split | if enabled, the split (side/top) will not change regardless of what happens to the container. | bool | false |
 | smart_split | if enabled, allows a more precise control over the window split direction based on the cursor's position. The window is conceptually divided into four triangles, and cursor's triangle determines the split direction. This feature also turns on preserve_split. | bool | false |
 | smart_resizing | if enabled, resizing direction will be determined by the mouse's position on the window (nearest to which corner). Else, it is based on the window's tiling position. | bool | true |
 | permanent_direction_override | if enabled, makes the preselect direction persist until either this mode is turned off, another direction is specified, or a non-direction is specified (anything other than l,r,u/t,d/b)  | bool | false | 
-| special_scale_factor | 0 - 1 -> specifies the scale factor of windows on the special workspace | float | 1 |
+| special_scale_factor | specifies the scale factor of windows on the special workspace [0 - 1] | float | 1 |
 | split_width_multiplier | specifies the auto-split width multiplier | float | 1.0 |
-| no_gaps_when_only | whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 | int | 0 |
+| no_gaps_when_only | whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 [0/1/2] | int | 0 |
 | use_active_for_splits | whether to prefer the active window or the mouse position for splits | bool | true |
-| default_split_ratio | the default split ratio on window open. 1 means even 50/50 split. 0.1 - 1.9 | float | 1.0 |
+| default_split_ratio | the default split ratio on window open. 1 means even 50/50 split. [0.1 - 1.9] | float | 1.0 |
 
 # Bind Dispatchers
 

--- a/pages/Configuring/Master-Layout.md
+++ b/pages/Configuring/Master-Layout.md
@@ -11,11 +11,11 @@ _category name `master`_
 | name | description | type | default |
 |---|---|---|---|
 | allow_small_split | enable adding additional master windows in a horizontal split style | bool | false |
-| special_scale_factor | (0.0 - 1.0) the scale of the special workspace windows | float | 1 |
-| mfact | (0.0 - 1.0) master split factor, the ratio of master split| float | 0.55 |
+| special_scale_factor | the scale of the special workspace windows. [0.0 - 1.0] | float | 1 |
+| mfact | master split factor, the ratio of master split [0.0 - 1.0] | float | 0.55 |
 | new_is_master | whether a newly open window should replace the master or join the slaves. | bool | true |
 | new_on_top | whether a newly open window should be on the top of the stack | bool | false |
-| no_gaps_when_only | whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 | int | 0 |
+| no_gaps_when_only | whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 [0/1/2] | int | 0 |
 | orientation | default placement of the master area, can be left, right, top, bottom or center | string | left |
 | inherit_fullscreen | inherit fullscreen status when cycling/swapping to another window (e.g. monocle layout) | bool | true |
 | always_center_master | when using orientation=center, keep the master window centered, even when it is the only window in the workspace. | bool | false |


### PR DESCRIPTION
Formatted ranges to facilitate scraping on the wiki's Configuring pages.
Following up #438

Ranges are now positioned at the end of the description, enclosed in brackets, with a "/" separator for lists of options or " - " for ranges.