### PR TITLE
Add Variables Link to hint under default config section

### DIFF
--- a/pages/Configuring/Configuring-Hyprland.md
+++ b/pages/Configuring/Configuring-Hyprland.md
@@ -14,7 +14,7 @@ The default config is not complete and does not list all the options / features 
 Please refer to this wiki page and the pages
 linked further down here for full configuration instructions.
 
-**Make sure to read the "[Variables](../Variables)" page as well**. It covers all the
+**Make sure to read the [Variables](../Variables) page as well**. It covers all the
 toggleable / numerical options.
 {{< /hint >}}
 

--- a/pages/Configuring/Configuring-Hyprland.md
+++ b/pages/Configuring/Configuring-Hyprland.md
@@ -14,7 +14,7 @@ The default config is not complete and does not list all the options / features 
 Please refer to this wiki page and the pages
 linked further down here for full configuration instructions.
 
-**Make sure to read the "Variables" page as well**. It covers all the
+**Make sure to read the "[Variables](../Variables)" page as well**. It covers all the
 toggleable / numerical options.
 {{< /hint >}}
 


### PR DESCRIPTION
Add a link to variables page underneath the default configuration section to encourage people to read the variables page.   