### PR TITLE
Example Volume Media Key Binds

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -320,7 +320,7 @@ These binds set the expected behavior for regular keyboard media volume keys,
 including when the screen is locked:
 
 ```ini
-bindl=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
-bindl=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
+bindel=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
+bindel=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 bindl=, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
 ```

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -311,3 +311,16 @@ submap=reset
 
 This works because the binds are executed in the order they appear, and
 assigning multiple actions per bind is possible.
+
+# Example Binds
+
+## Media
+
+These binds set the expected behavior for regular keyboard media volume keys,
+including when the screen is locked:
+
+```ini
+bindl=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
+bindl=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
+bindl=, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+```


### PR DESCRIPTION
Added example bindings for volume media keys in pages/Configuring/Binds.md in an Examples section at the bottom