### PR TITLE
Fix Config File Path for hypridle and hyprpaper

### DIFF
--- a/pages/Hypr Ecosystem/hypridle.md
+++ b/pages/Hypr Ecosystem/hypridle.md
@@ -4,7 +4,7 @@ hypridle is hyprland's idle management daemon.
 
 ## Configuration
 
-Configuration is done via the config file at `~/.config/hypridle.conf`.
+Configuration is done via the config file at `~/.config/hypr/hypridle.conf`.
 A config file is required; hypridle won't run without one.
 
 ### General

--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -4,7 +4,7 @@ hyprpaper is a fast, IPC-controlled wallpaper utility for hyprland.
 
 ## Configuration
 
-The config file is located at `~/.config/hypridle.conf`. It is not required.
+The config file is located at `~/.config/hypr/hyprpaper.conf`. It is not required.
 
 Configuration is done via `preload`s, which _load_ an image into memory.
 Then, you use `wallpaper` keywords to apply the preloaded image to your


### PR DESCRIPTION
Fixes Config Paths For hypridle and hyprpaper:
* `~/.config/hypridle.conf` -> `~/.config/hypr/hypridle.conf` [Source](https://github.com/hyprwm/hypridle?tab=readme-ov-file#configuration)
* `~/.config/hypridle.conf` -> `~/.config/hypr/hyprpaper.conf` [Source](https://github.com/hyprwm/hyprpaper?tab=readme-ov-file#usage)