### PR TITLE
add config info for hyprlock

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -5,7 +5,7 @@ lock for hyprland.
 
 ## Configuration
 
-Configuration is done via the config file at `~/.config/hypr/hyprlock.conf`. It is not required but recommended because without it locking shows current screen.
+Configuration is done via the config file at `~/.config/hypr/hyprlock.conf`. It is not required, but recommended. Without it, locking shows the current screen.
 ### General
 
 Variables in the `general` category:

--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -5,6 +5,7 @@ lock for hyprland.
 
 ## Configuration
 
+Configuration is done via the config file at `~/.config/hypr/hyprlock.conf`. It is not required but recommended because without it locking shows current screen.
 ### General
 
 Variables in the `general` category:


### PR DESCRIPTION
Simple addition of config file location to wiki. Easier for users to understand where to find config file and more inline with other hyprland-ecosystem packages wiki. Also, noteworthy to mention that without config file hyprlock shows current screen.