### PR TITLE
Update the documentation for mapping touch device and tablet inputs to outputs

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -247,7 +247,7 @@ _Subcategory `input:touchdevice:`_
 | name | description | type | default |
 |---|---|---|---|
 | transform | transform the input from touchdevices. The possible transformations are the same as [those of the monitors](../Monitors/#rotating) | int | 0 |
-| output | the monitor to bind touch devices. Empty means unset and will use the current / autodetected. | string | \[\[Empty\]\] |
+| output | the monitor to bind touch devices. The default is autodetection. To stop autotection use an empty string or the "\[\[Empty\]\]" value. | string | \[\[Auto\]\] |
 | enabled | Whether input is enabled for touch devices. | bool | true |
 
 
@@ -258,7 +258,7 @@ _Subcategory `input:tablet:`_
 | name | description | type | default |
 |---|---|---|---|
 | transform | transform the input from tablets. The possible transformations are the same as [those of the monitors](../Monitors/#rotating) | int | 0 |
-| output | the monitor to bind tablets. Empty means unset and will use the current / autodetected. | string | \[\[Empty\]\] |
+| output | the monitor to bind tablets. Empty means unbound. | string | \[\[Empty\]\] |
 | region_position | position of the mapped region in monitor layout. | vec2 | [0, 0] |
 | region_size | size of the mapped region. When this variable is set, tablet input will be mapped to the region. [0, 0] or invalid size means unset. | vec2 | [0, 0] |
 | relative_input | whether the input should be relative | bool | false |


### PR DESCRIPTION
PR for: hyprwm/Hyprland#3544

Updates:

 - touch devices can be unbound with an empty string or the `[[Empty]]` value
 - the default for touch devices is `[[Auto]]` where Hyprland will try to get the default output name from wlroots
 - tablet input devices don't autodetect an input (wlr doesn't provide a default output name for tablet devices)