### PR TITLE
Fixed a broken link to the screensharing gist

### DIFF
--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -8,7 +8,7 @@ if you don't have them yet.
 ## Screensharing
 
 Read
-[this amazing gist by PowerBall253](https://gist.github.com/PowerBall253/2dea6ddf6974ba4e5d26c3139ffb7580)
+[this amazing gist by Bruno Ancona Sala](https://gist.github.com/brunoanc/2dea6ddf6974ba4e5d26c3139ffb7580)
 for a great tutorial.
 
 ## Better screensharing


### PR DESCRIPTION
Mr. Powerball253 (or Bruno as I guess he is called) changed his GitHub account name, which broke the link to the screensharing gist. Thankfully, the link still works if with his new GitHub account name. I don't know if he wants his full name in the wiki, so @brunoanc let me know if you want me to change it to something else.