### PR TITLE
Fix bash shebangs for NixOS users

### DIFF
--- a/pages/Configuring/Expanding-functionality.md
+++ b/pages/Configuring/Expanding-functionality.md
@@ -13,7 +13,7 @@ This bash script will change the outer gaps to 20 if the currently focused
 monitor is DP-1, and 30 otherwise.
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 function handle {
   if [[ ${1:0:10} == "focusedmon" ]]; then

--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -212,7 +212,7 @@ they might launch before that has happened.
 In such cases, a script like this:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 sleep 4
 killall -e xdg-desktop-portal-wlr
 killall xdg-desktop-portal

--- a/pages/Useful Utilities/Hyprland-desktop-portal.md
+++ b/pages/Useful Utilities/Hyprland-desktop-portal.md
@@ -98,7 +98,7 @@ XDPH will work on other wlroots compositors, but features available only on Hypr
 
 For a nuclear option, you can use this script and `exec-once` it:
 ```sh
-#!/bin/bash
+#!/usr/bin/env bash
 sleep 1
 killall -e xdg-desktop-portal-hyprland
 killall -e xdg-desktop-portal-wlr

--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -119,7 +119,7 @@ This widget displays a list of workspaces 1-10. Each workspace can be clicked on
 ### `~/.config/eww/scripts/change-active-workspace`
 
 ```sh
-#! /bin/bash
+#!/usr/bin/env bash
 function clamp {
 	min=$1
 	max=$2
@@ -156,7 +156,7 @@ socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - |
 ### `~/.config/eww/scripts/get-workspaces`
 
 ```sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 spaces (){
 	WORKSPACE_WINDOWS=$(hyprctl workspaces -j | jq 'map({key: .id | tostring, value: .windows}) | from_entries')


### PR DESCRIPTION
I know it's a bit of a nit pick, but copy-paste won't work when trying the examples for eww bar in NixOS.  There are a couple of places in the documentation where `/bin/bash` is referenced (this doesn't exist on NixOS).  For compatibility reasons, I've changed references to `/bin/bash` to `/usr/bin/env bash`.  `/bin/sh` is intact since it isn't an issue.