### PR TITLE
Remove outdated information

### DIFF
--- a/pages/Configuring/Keywords.md
+++ b/pages/Configuring/Keywords.md
@@ -130,8 +130,6 @@ device {
 }
 ```
 
-_remember about the space after the end of the device's name (before the `{`)!_
-
 {{< hint type=info >}}
 Per-device layouts will by default not alter the keybind keymap, so for example with a global keymap of `us`
 and a per-device one of `fr`, the keybinds will still act as if you were on `us`.


### PR DESCRIPTION
Remove a hint that suggested the name of the device be written as `device:<device-name>`.