### PR TITLE
Update deprecated nofullscreenrequest occurrence in FAQ

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -303,9 +303,10 @@ Wayland compositors, you will have to do few tweaks. For Hyprland, you can add
 these window rules to your config to make said programs work with both of your
 screens.
 
-```windowrulev2=float,title:^(flameshot)
+```ini
+windowrulev2=float,title:^(flameshot)
 windowrulev2=move 0 0,title:^(flameshot)
-windowrulev2=nofullscreenrequest,title:^(flameshot)
+windowrulev2=suppressevent fullscreen,title:^(flameshot)
 ```
 
 ### I cannot bind SUPER as my mod key on my laptop


### PR DESCRIPTION
Hi, I updated my system recently and noticed that the window rule `nofullscreenrequest` has been [deprecated and removed](https://github.com/hyprwm/Hyprland/commit/7f52db806c149cb3331d6567706e7c19f5a8b692) in favor of `suppressevent`. 

There is still a trace of the old rule in the FAQ/multimonitor screenshot. While updating the doc, I also noticed the first line of the code block was on the same line of the block fence, so it was interpreted as the language and therefore not displayed on the website.

I searched the codebase and found no other occurrences of `nofullscreenrequest` or `nomaximizerequest`, so I guess this should fix it.