### PR TITLE
hyprlock: add `ignore_empty_input` and description

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -21,6 +21,7 @@ Variables in the `general` category:
 | grace | the amount of seconds for which the lockscreen will unlock on mouse movement. | int | 0 |
 | no_fade_in | disables the fadein animation | bool | false |
 | no_fade_out | disables the fadeout animation | bool | false |
+| ignore_empty_input | skips validation when empty password is provided | bool | false |
 
 ## Widgets
 


### PR DESCRIPTION
Added `ignore_empty_input` that allows skipping validation when empty password is provided.
