### PR TITLE
update switchxkblayout example using name key

### DIFF
--- a/pages/Configuring/Using-hyprctl.md
+++ b/pages/Configuring/Using-hyprctl.md
@@ -126,7 +126,8 @@ Sets the xkb layout index for a keyboard.
 For example, if you set:
 
 ```ini
-device:my-epic-keyboard-v1 {
+device {
+    name=my-epic-keyboard-v1
     kb_layout=us,pl,de
 }
 ```


### PR DESCRIPTION
```ini
device:my-epic-keyboard-v1 {
    kb_layout=us,pl,de
}
```
does no longer work, but it does work when using
```ini
device {
    name=my-epic-keyboard-v1
    kb_layout=us,pl,de
}
```