### PR TITLE
Add hyprlock default keypress behaviour

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -30,9 +30,7 @@ The following keys and key-combinations describe hyprlocks default behaviour:
 | -- | -- |
 | ESC | Clear password buffer |
 | Ctrl + u | Clear password buffer |
-| Ctrl + BackSpace | Clear password buffer |
-| Enter / Return | start authentication |
-| BackSpace | remove character from input buffer |
+| Ctrl + Backspace | Clear password buffer |
 
 ## Widgets
 

--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -23,6 +23,17 @@ Variables in the `general` category:
 | no_fade_out | disables the fadeout animation | bool | false |
 | ignore_empty_input | skips validation when empty password is provided | bool | false |
 
+## Keyboard Shortcuts and Actions
+
+The following keys and key-combinations describe hyprlocks default behaviour:
+| input | description | 
+| -- | -- |
+| ESC | Clear password buffer |
+| Ctrl + u | Clear password buffer |
+| Ctrl + BackSpace | Clear password buffer |
+| Enter / Return | start authentication |
+| BackSpace | remove character from input buffer |
+
 ## Widgets
 
 The entire configuration of how hyprlock looks is done via widgets.


### PR DESCRIPTION
According to https://github.com/hyprwm/hyprland-wiki/issues/579 the wiki was lacking default behaviour, so i quickly added it.

I hope i didn't miss any keyboard shortcuts or input behaviour. I placed it after `Configuration` but before `Widgets` because i don't really know where it fits best. Might aswell move it before `Configuration` since it's default behaviour?