### PR TITLE
Expand on window matching

### DIFF
--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -10,7 +10,7 @@ layout pages (See the sidebar).
 
 | Param type | Description |
 | --- | --- |
-| window | a window. Any of the following: Class regex, `title:` and a title regex, `pid:` and the pid, `address:` and the address, `floating`, `tiled` |
+| window | a window. Any of the following: class regex (by default, optionally `class:`), `initialclass:` initial class regex, `title:` title regex, `initialtitle` initial title regex, `pid:` the pid, `address:` the address, `activewindow` an active window, `floating` the first floating window on the current workspace, `tiled` the first tiled window on the current workspace |
 | workspace | see below. |
 | direction | `l` `r` `u` `d` left right up down |
 | monitor | One of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |


### PR DESCRIPTION
Companion PR for https://github.com/hyprwm/Hyprland/pull/5518.
Adds info about the new rules, a note about default mode & `class:` support, and adds extra info on `floating` & `tiled` matchers.