### PR TITLE
Remove ~, replace with full path

### DIFF
--- a/pages/Configuring/Multi-GPU.md
+++ b/pages/Configuring/Multi-GPU.md
@@ -65,7 +65,6 @@ If instead you would like to use another GPU, you must first create a symlink to
 the card from the previous section.
 
 It is not possible to use `~/.config/hypr/card` as wlroots will not expand it correctly.  
-
 You must include full path e.g `/home/<user>/.config/hypr/card` 
 ```
 ln -sf /dev/dri/pci-0000:06:00.0-card /home/<user>/.config/hypr/card

--- a/pages/Configuring/Multi-GPU.md
+++ b/pages/Configuring/Multi-GPU.md
@@ -64,8 +64,11 @@ required. wlroots will set `WLR_DRM_DEVICES` to the integrated GPU by default.
 If instead you would like to use another GPU, you must first create a symlink to
 the card from the previous section.
 
+It is not possible to use `~/.config/hypr/card` as wlroots will not expand it correctly.  
+
+You must include full path e.g `/home/<user>/.config/hypr/card` 
 ```
-ln -sf /dev/dri/pci-0000:06:00.0-card ~/.config/hypr/card
+ln -sf /dev/dri/pci-0000:06:00.0-card /home/<user>/.config/hypr/card
 ```
 
 It is not possible to directly use the `/dev/dri/pci-0000:06:00.0-card` path,
@@ -75,15 +78,16 @@ characters will not rectify this.
 Afterwards, you must set the `WLR_DRM_DEVICES` environment variable in
 hyprland.conf to this linked card.
 
+
 ```ini
-env = WLR_DRM_DEVICES,~/.config/hypr/card
+env = WLR_DRM_DEVICES,/home/<user>/.config/hypr/card
 ```
 
 If you want to set a sequence of fallback cards, symlink another card and set
 the var as a colon separated list in order of priority.
 
 ```ini
-env = WLR_DRM_DEVICES,~/.config/hypr/card:~/.config/hypr/otherCard
+env = WLR_DRM_DEVICES,/home/<user>/.config/hypr/card:/home/<user>/.config/hypr/otherCard
 ```
 
 Here, we tell Hyprland to set priorities. If `card` isn't available for

--- a/pages/Configuring/Multi-GPU.md
+++ b/pages/Configuring/Multi-GPU.md
@@ -65,9 +65,9 @@ If instead you would like to use another GPU, you must first create a symlink to
 the card from the previous section.
 
 It is not possible to use `~/.config/hypr/card` as wlroots will not expand it correctly.  
-You must include full path e.g `/home/<user>/.config/hypr/card` 
+You must include full path e.g `$HOME/.config/hypr/card`
 ```
-ln -sf /dev/dri/by-path/pci-0000:06:00.0-card /home/<user>/.config/hypr/card
+ln -sf /dev/dri/by-path/pci-0000:06:00.0-card $HOME/.config/hypr/card
 ```
 
 It is not possible to directly use the `/dev/dri/by-path/pci-0000:06:00.0-card` path,
@@ -79,14 +79,14 @@ hyprland.conf to this linked card.
 
 
 ```ini
-env = WLR_DRM_DEVICES,/home/<user>/.config/hypr/card
+env = WLR_DRM_DEVICES,$HOME/.config/hypr/card
 ```
 
 If you want to set a sequence of fallback cards, symlink another card and set
 the var as a colon separated list in order of priority.
 
 ```ini
-env = WLR_DRM_DEVICES,/home/<user>/.config/hypr/card:/home/<user>/.config/hypr/otherCard
+env = WLR_DRM_DEVICES,$HOME/.config/hypr/card:$HOME/.config/hypr/otherCard
 ```
 
 Here, we tell Hyprland to set priorities. If `card` isn't available for

--- a/pages/Configuring/Multi-GPU.md
+++ b/pages/Configuring/Multi-GPU.md
@@ -67,10 +67,10 @@ the card from the previous section.
 It is not possible to use `~/.config/hypr/card` as wlroots will not expand it correctly.  
 You must include full path e.g `/home/<user>/.config/hypr/card` 
 ```
-ln -sf /dev/dri/pci-0000:06:00.0-card /home/<user>/.config/hypr/card
+ln -sf /dev/dri/by-path/pci-0000:06:00.0-card /home/<user>/.config/hypr/card
 ```
 
-It is not possible to directly use the `/dev/dri/pci-0000:06:00.0-card` path,
+It is not possible to directly use the `/dev/dri/by-path/pci-0000:06:00.0-card` path,
 as wlroots interprets the colon symbols in the path as separators. Escaping
 characters will not rectify this.
 


### PR DESCRIPTION
It seems that [wlroots can't](https://github.com/hyprwm/Hyprland/issues/5553) expand the ~ for user home directory, so full path must be used without it.
 pinging @kiecla as they initially wrote it and there may be some misunderstanding, assuming it worked for them when it was wrote. 