### PR TITLE
windowrulev2: fix typo

### DIFF
--- a/pages/Configuring/Window-Rules.md
+++ b/pages/Configuring/Window-Rules.md
@@ -65,13 +65,13 @@ terminals.
 
 {{< /callout >}}
 
-For now, the supported fields are:
+For now, the supported fields for V2 are:
 
 ```ini
 class - class regex 
 title - title regex
 initialclass - initialClass regex
-initialtitle - initialTitle regex
+initialTitle - initialTitle regex
 xwayland - 0/1
 floating - 0/1
 fullscreen - 0/1


### PR DESCRIPTION
`initialtitle` (without capital T) actually matches `title` instead (see https://github.com/hyprwm/Hyprland/issues/5550).
Also explicitly say that the supported fields are only for v2 since they do not work for v1 and I at least oversaw they were listed in the v2 section. 