### PR TITLE
Fix "GDK_BAKCENDS"

### DIFF
--- a/pages/Configuring/Environment-variables.md
+++ b/pages/Configuring/Environment-variables.md
@@ -41,7 +41,7 @@ environment on traditional Linux distros.
 
 ## Toolkit Backend Variables
 
-- `env = GDK_BACKEND,wayland;x11` - GTK: Use wayland if available, fall back to x11 if
+- `env = GDK_BACKEND,wayland,x11` - GTK: Use wayland if available, fall back to x11 if
   not.
 - `env = QT_QPA_PLATFORM,wayland;xcb` - Qt: Use wayland if available, fall back to
   x11 if not.


### PR DESCRIPTION
GDK_BACKENDS support comma(not ";") separated backend names. Shit won't work with ';' as separator. From the gtk docs: "This environment variable can contain a comma-separated list of backend names, which are tried in order. "