### PR TITLE
GDK_BACKEND separator fix and try any backend

### DIFF
--- a/pages/Configuring/Environment-variables.md
+++ b/pages/Configuring/Environment-variables.md
@@ -41,7 +41,7 @@ environment on traditional Linux distros.
 
 ## Toolkit Backend Variables
 
-- `env = GDK_BACKEND,wayland;x11` - GTK: Use wayland if available, fall back to x11 if
+- `env = GDK_BACKEND,wayland,x11,*` - GTK: Use wayland if available. If not: try x11, then any other GDK backend.
   not.
 - `env = QT_QPA_PLATFORM,wayland;xcb` - Qt: Use wayland if available, fall back to
   x11 if not.


### PR DESCRIPTION
GDK_BACKEND only supports comma separator. Also added try for any gdk backend after x11.