### PR TITLE
App-Clients: change gtkcord4 to dissent

### DIFF
--- a/pages/Useful Utilities/App-Clients.md
+++ b/pages/Useful Utilities/App-Clients.md
@@ -13,7 +13,7 @@ replacements for them:
   PipeWire screensharing. It has tons of great features and tries not to
   infringe on the Discord ToS.
 
-- [gtkcord4](https://github.com/diamondburned/gtkcord4) is a Discord client
+- [dissent](https://github.com/diamondburned/dissent) is a Discord client
   written in GTK4. While it does infringe on Discord's ToS, it's relatively safe
   and doesn't rely on any webview technologies.
 


### PR DESCRIPTION
Name of gtkcord4 was changed to dissent by diamondburned. Although the old link still points to the same repo, it would still be better if we changed name as one might try to search it in a browser directly (like me)