### PR TITLE
Simplify keybind generation code for workspaces

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -137,13 +137,10 @@ module, or the flake-based Home Manager module.
         # binds $mod + [shift +] {1..10} to [move to] workspace {1..10}
         builtins.concatLists (builtins.genList (
             x: let
-              ws = let
-                c = (x + 1) / 10;
-              in
-                builtins.toString (x + 1 - (c * 10));
+              ws = builtins.toString (x + 10);
             in [
-              "$mod, ${ws}, workspace, ${toString (x + 1)}"
-              "$mod SHIFT, ${ws}, movetoworkspace, ${toString (x + 1)}"
+              "$mod, code:${ws}, workspace, ${toString (x + 1)}"
+              "$mod SHIFT, code:${ws}, movetoworkspace, ${toString (x + 1)}"
             ]
           )
           10)


### PR DESCRIPTION
Change workspace keybind generation to use keycodes instead of  numbers. This makes the code snippet work with different layouts. Removed redundant code.