### PR TITLE
add missing semicolon

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -61,7 +61,7 @@ this:
         ./configuration.nix
       ];
     };
-  } 
+  };
 }
 
 # configuration.nix


### PR DESCRIPTION
which produced an error when I ran `sudo nixos-rebuild boot --impure --flake /etc/nixos/#`