### PR TITLE
Add missing Bind flag and fixed typos

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -186,7 +186,7 @@ n -> non-consuming, key/mouse events will be passed to the active window in addi
 m -> mouse, see below.
 t -> transparent, cannot be shadowed by other binds.
 i -> ignore mods, will ignore modifiers.
-s -> separate, will arbitrarily combine keys between each mod/key, see [Keysym combos](./Binds.md/#keysym-combos) above.
+s -> separate, will arbitrarily combine keys between each mod/key, see [Keysym combos](#keysym-combos) above.
 d -> has description, will allow you to write a description for your bind.
 ```
 

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -89,7 +89,7 @@ bindr=SUPERALT,Alt_L,exec,amongus
 
 ### Keysym combos
 
-For an arbitrary combination of multiple keys, seperate keysyms with `&` between
+For an arbitrary combination of multiple keys, separate keysyms with `&` between
 each mod/key and use the `s` flag, e.g.:
 
 ```ini
@@ -302,8 +302,8 @@ Will send <key>SUPER</key> + <key>F4</key> to OBS if you press <key>SUPER</key> 
 
 {{< callout >}}
 
-This works flawlessly with all native Wayland applications. However, XWayland is a bit wonky. 
-Make sure that what you're passing is a "global Xorg keybind", 
+This works flawlessly with all native Wayland applications. However, XWayland is a bit wonky.
+Make sure that what you're passing is a "global Xorg keybind",
 otherwise passing from a different XWayland app may not work.
 
 {{< /callout >}}
@@ -336,7 +336,7 @@ Please note that this function will _only_ work with
 ## Submaps
 
 Keybind submaps, also known as _modes_ or _groups_, allow you to activate a
-seperate set of keybinds. For example, if you want to enter a "resize" mode 
+separate set of keybinds. For example, if you want to enter a "resize" mode 
 which allows you to resize windows with the arrow keys, you can do it like this:
 
 ```ini

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -183,9 +183,10 @@ l -> locked, will also work when an input inhibitor (e.g. a lockscreen) is activ
 r -> release, will trigger on release of a key.
 e -> repeat, will repeat when held.
 n -> non-consuming, key/mouse events will be passed to the active window in addition to triggering the dispatcher.
-m -> mouse, see below
+m -> mouse, see below.
 t -> transparent, cannot be shadowed by other binds.
 i -> ignore mods, will ignore modifiers.
+s -> separate, will arbitrarily combine keys between each mod/key, see [Keysym combos](./Binds.md/#keysym-combos) above.
 d -> has description, will allow you to write a description for your bind.
 ```
 

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -37,6 +37,10 @@ rgb(), e.g. `rgb(b3ff1a)`
 
 legacy, e.g. `0xeeb3ff1a` -> ARGB order
 
+{{< /callout >}}
+
+{{< callout type=info >}}
+
 **_Mod list:_**
 
 ```ini
@@ -392,7 +396,7 @@ _Subcategory `group:groupbar:`_
 
 | name | description | type | default |
 | --- | --- | --- | --- |
-| use_nearest_neighbor | uses the nearest neigbor filtering for xwayland apps, making them pixelated rather than blurry | bool | true |
+| use_nearest_neighbor | uses the nearest neighbor filtering for xwayland apps, making them pixelated rather than blurry | bool | true |
 | force_zero_scaling | forces a scale of 1 on xwayland windows on scaled displays. | bool | false |
 
 ### OpenGL


### PR DESCRIPTION
In the Binds page:
- I've added the "s" flag for the binds, it's documented in the page but not in the flags list.
- I've also fixed some typos and trailing spaces

In the Variables page:
- The "Mod List" was grouped with the "Colors" in the info callout. I separated them on their own hints.
- Also fixed a typo in the XWayland table.