### PR TITLE
Installation: updated Arch build dependencies

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -226,7 +226,7 @@ Dependencies:
 {{% details title="Arch" closed="true" %}}
 
 ```plain
-yay -S gdb ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite xorg-xinput libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang hyprcursor
+yay -S gdb ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite xorg-xinput libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang hyprcursor hyprwayland-scanner xcb-util-errors
 ```
 
 _(Please make a pull request or open an issue if any packages are missing from


### PR DESCRIPTION
Added `hyprwayland-scanner` and `xcb-util-errors` dependencies to _Manual Build_ - _Arch_ section of the _Instalation_ wiki page. (implements #624)