### PR TITLE
Add description to key binds

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -148,7 +148,7 @@ The keybinds will be executed in the order they were created. (top to bottom)
 ### Description
 
 You can describe you keybind with the description flag.
-Your description always goes in front of the dispatcher and should never contain the character ´,´!
+Your description always goes in front of the dispatcher and should never contain the character `,`!
 
 ```ini
 bindd=MODS,key,description,dispatcher,params
@@ -160,7 +160,7 @@ for example,
 bindd=SUPER,Q,Open my favourite terminal,exec,kitty
 ```
 
-If you want to access your description you can use `hyprctl binds`. For more information have a look at [Useing Hyprctl](./Using-hyprctl.md).
+If you want to access your description you can use `hyprctl binds`. For more information have a look at [Using Hyprctl](./Using-hyprctl.md).
 
 ## Bind flags
 

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -145,6 +145,23 @@ bind = SUPER,Tab,bringactivetotop,   # bring it to the top
 
 The keybinds will be executed in the order they were created. (top to bottom)
 
+### Description
+
+You can describe you keybind with the description flag.
+Your description always goes in front of the dispatcher and should never contain the character ´,´!
+
+```ini
+bindd=MODS,key,description,dispatcher,params
+```
+
+for example,
+
+```ini
+bindd=SUPER,Q,Open my favourite terminal,exec,kitty
+```
+
+If you want to access your description you can use `hyprctl binds`. For more information have a look at [Useing Hyprctl](./Using-hyprctl.md).
+
 ## Bind flags
 
 `bind` supports flags in this format:
@@ -169,6 +186,7 @@ n -> non-consuming, key/mouse events will be passed to the active window in addi
 m -> mouse, see below
 t -> transparent, cannot be shadowed by other binds.
 i -> ignore mods, will ignore modifiers.
+d -> has description, will allow you to write a description for your bind.
 ```
 
 Example Usage:
@@ -182,6 +200,9 @@ bindl=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 
 # Start wofi opens wofi on first press, closes it on second
 bindr=SUPER, SUPER_L, exec, pkill wofi || wofi
+
+# Describe a bind
+bindd=SUPER,Q,Open my favourite terminal,exec,kitty
 
 # See Mouse Binds section for bindm usage
 ```

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -137,7 +137,7 @@ You can view your switches in `hyprctl devices`.
 You can trigger multiple actions with one keybind by assigning multiple binds to
 one combination, e.g.:
 
-```
+```ini
 # to switch between windows in a floating workspace
 bind = SUPER,Tab,cyclenext,          # change focus to another window
 bind = SUPER,Tab,bringactivetotop,   # bring it to the top

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -321,7 +321,7 @@ Choose whichever you like, for example `coolApp:myToggle`
 
 Bind it to whatever you want with the `global` dispatcher:
 
-```
+```ini
 bind = SUPERSHIFT, A, global, coolApp:myToggle
 ```
 

--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -147,7 +147,7 @@ The keybinds will be executed in the order they were created. (top to bottom)
 
 ### Description
 
-You can describe you keybind with the description flag.
+You can describe your keybind with the description flag.
 Your description always goes in front of the dispatcher and should never contain the character `,`!
 
 ```ini


### PR DESCRIPTION
Added docs for PR [hyprwm/Hyprland#6338](https://github.com/hyprwm/Hyprland/pull/6358) and fixed two code blocks in the binds section that had no highlight. 