### PR TITLE
added clarification on enabling no_hardware_cursors

### DIFF
--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -99,12 +99,16 @@ env = LIBVA_DRIVER_NAME,nvidia
 env = XDG_SESSION_TYPE,wayland
 env = GBM_BACKEND,nvidia-drm
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
+
+cursor {
+    no_hardware_cursors = true
+}
 ```
 
 {{< callout type=warning >}}
 
 Previously used `WLR_NO_HARDWARE_CURSORS` environment variable has been deprecated.
-Do not set it in your configs. See: [cursor](../Configuring/Variables/#cursor)
+Do not set it in your configs. Use `cursor:no_hardware_cursors` instead.
 
 {{< /callout >}}
 


### PR DESCRIPTION
Since disabling hardware cursors is still an important part of having a good time on Hyprland with NVIDIA hardware, it should be better clarified instead of linking to the Variables page with only a warning about WLR_NO_HARDWARE_CURSORS being depreciated.