### PR TITLE
Update _index.md: emphasize NixOS module requirement

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -7,9 +7,11 @@ For a list of available options, check the
 
 {{< callout >}}
 
-- _(Required) NixOS Module_: enables critical components needed to run Hyprland
+- _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
   properly
-- _(Optional) Home-manager module_: lets you declaratively configure Hyprland
+- _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
+  - _This module configures Hyprland and adds it to your user's `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
+
   {{< /callout >}}
 
 ## Installation

--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -7,11 +7,16 @@ For a list of available options, check the
 
 {{< callout >}}
 
-- _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
-  properly. 
-  - _Without this, you may have issues with XDG Portals, or missing session files in your Display Manager._
-- _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
-  - _This module configures Hyprland and adds it to your user's `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
+- _**(Required)** NixOS Module_: enables critical components needed to run
+  Hyprland properly.
+  - _Without this, you may have issues with XDG Portals, or missing session
+    files in your Display Manager._
+- _(Optional) Home Manager module_: lets you configure Hyprland declaratively
+  through Home Manager.
+  - _This module configures Hyprland and adds it to your user's `$PATH`, but
+    does not make certain system-level changes such as adding a desktop session
+    file for your display manager. This is handled by the NixOS module once you
+    enable it._
 
   {{< /callout >}}
 

--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -13,9 +13,10 @@ Make sure to check out the options of the
 
 {{< callout >}}
 
-- _(Required) NixOS Module_: enables critical components needed to run Hyprland
+- _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
   properly
-- _(Optional) Home-manager module_: lets you declaratively configure Hyprland
+- _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
+  - _This module configures Hyprland and adds it to your user's `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
 
 {{< /callout >}}
 

--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -13,11 +13,16 @@ Make sure to check out the options of the
 
 {{< callout >}}
 
-- _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
-  properly
-  - _Without this, you may have issues with XDG Portals, or missing session files in your Display Manager._
-- _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
-  - _This module configures Hyprland and adds it to your user's `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
+- _**(Required)** NixOS Module_: enables critical components needed to run
+  Hyprland properly
+  - _Without this, you may have issues with XDG Portals, or missing session
+    files in your Display Manager._
+- _(Optional) Home Manager module_: lets you configure Hyprland declaratively
+  through Home Manager.
+  - _This module configures Hyprland and adds it to your user's `$PATH`, but
+    does not make certain system-level changes such as adding a desktop session
+    file for your display manager. This is handled by the NixOS module once you
+    enable it._
 
 {{< /callout >}}
 

--- a/pages/Nix/_index.md
+++ b/pages/Nix/_index.md
@@ -10,7 +10,7 @@ To install Hyprland on NixOS, we provide a NixOS and a Home Manager module.
 - _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
   properly
 - _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
-  - _Note that this does_ not _install Hyprland; since it would require system-level changes such as adding a session file for your display manager. This is handled by the NixOS module once you enable it._ 
+  - _This module configures Hyprland and adds it to your users' `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
 
 {{< /callout >}}
 

--- a/pages/Nix/_index.md
+++ b/pages/Nix/_index.md
@@ -10,7 +10,7 @@ To install Hyprland on NixOS, we provide a NixOS and a Home Manager module.
 - _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
   properly
 - _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
-  - _This module configures Hyprland and adds it to your users' `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
+  - _This module configures Hyprland and adds it to your user's `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
 
 {{< /callout >}}
 

--- a/pages/Nix/_index.md
+++ b/pages/Nix/_index.md
@@ -7,11 +7,16 @@ To install Hyprland on NixOS, we provide a NixOS and a Home Manager module.
 
 {{< callout title=Note >}}
 
-- _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
-  properly
-  - _Without this, you may have issues with XDG Portals, or missing session files in your Display Manager._
-- _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
-  - _This module configures Hyprland and adds it to your user's `$PATH`, but does not make certain system-level changes such as adding a desktop session file for your display manager. This is handled by the NixOS module once you enable it._
+- _**(Required)** NixOS Module_: enables critical components needed to run
+  Hyprland properly
+  - _Without this, you may have issues with XDG Portals, or missing session
+    files in your Display Manager._
+- _(Optional) Home Manager module_: lets you configure Hyprland declaratively
+  through Home Manager.
+  - _This module configures Hyprland and adds it to your user's `$PATH`, but
+    does not make certain system-level changes such as adding a desktop session
+    file for your display manager. This is handled by the NixOS module once you
+    enable it._
 
 {{< /callout >}}
 

--- a/pages/Nix/_index.md
+++ b/pages/Nix/_index.md
@@ -7,9 +7,10 @@ To install Hyprland on NixOS, we provide a NixOS and a Home Manager module.
 
 {{< callout title=Note >}}
 
-- _(Required) NixOS Module_: enables critical components needed to run Hyprland
+- _**(Required)** NixOS Module_: enables critical components needed to run Hyprland
   properly
-- _(Optional) Home-manager module_: lets you declaratively configure Hyprland
+- _(Optional) Home-manager module_: lets you configure Hyprland declaratively through home-manager.
+  - _Note that this does_ not _install Hyprland; since it would require system-level changes such as adding a session file for your display manager. This is handled by the NixOS module once you enable it._ 
 
 {{< /callout >}}
 


### PR DESCRIPTION
Too many people get confused and don't want to enable the NixOS module. This PR changes the wording to emphasize that it is indeed required, and that you still need to install Hyprland if you just use the HM module.