### PR TITLE
Document `NIXOS_OZONE_WL=1`

### DIFF
--- a/pages/Getting Started/Master-Tutorial.md
+++ b/pages/Getting Started/Master-Tutorial.md
@@ -112,7 +112,8 @@ A lot of apps will use Wayland by default. Chromium (and other browsers based on
 it or electron) don't. You need to pass
 `--enable-features=UseOzonePlatform --ozone-platform=wayland` to them or use
 `.conf` files where possible. Chromium-based browsers also should have a toggle
-in `chrome://flags`. Search for _"ozone"_ and select Wayland.
+in `chrome://flags`. Search for _"ozone"_ and select Wayland. If you are on NixOS
+You can also use `NIXOS_OZONE_WL=1`.
 
 For most electron apps, you should put the above in
 `~/.config/electron-flags.conf`. VSCode is known to not work with that though.

--- a/pages/Getting Started/Master-Tutorial.md
+++ b/pages/Getting Started/Master-Tutorial.md
@@ -113,7 +113,7 @@ it or electron) don't. You need to pass
 `--enable-features=UseOzonePlatform --ozone-platform=wayland` to them or use
 `.conf` files where possible. Chromium-based browsers also should have a toggle
 in `chrome://flags`. Search for _"ozone"_ and select Wayland. If you are on NixOS
-You can also use `NIXOS_OZONE_WL=1`.
+you can also set the environment variable `NIXOS_OZONE_WL=1` in your configuration.
 
 For most electron apps, you should put the above in
 `~/.config/electron-flags.conf`. VSCode is known to not work with that though.


### PR DESCRIPTION
Documents nifty NixOS specific environment variable that allows Electron apps to run under Wayland, NixOS is only distro that adds this nifty feature works in all apps I have tested and it is personally what I use. Can be found at https://nixos.wiki/wiki/Wayland