### PR TITLE
Clarify usage of `hyprctl setprop` and `exec` dispatcher with dynamic rules

### DIFF
--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -180,6 +180,9 @@ bind = SUPER, C, movetoworkspace, special
 The `exec` dispatcher supports adding rules. Please note some windows might work
 better, some worse. It records the PID of the spawned process and uses that. For example, if
 your process forks and then the fork opens a window, this will not work.
+Rules will only be applied once. This means dynamic rules will be overridden as soon as a 
+property of the window changes (e.g. switching focus). To make dynamic rules stick around
+use `hyprctl setprop` (see [Using hyprctl](./Using-hyprctl)).
 
 The syntax is:
 
@@ -190,5 +193,5 @@ bind = mod, key, exec, [rules...] command
 For example:
 
 ```
-bind = SUPER, E, exec, [workspace 2 silent;float;noanim] kitty
+bind = SUPER, E, exec, [workspace 2 silent; float; move 0 0] kitty
 ```

--- a/pages/Configuring/Using-hyprctl.md
+++ b/pages/Configuring/Using-hyprctl.md
@@ -198,6 +198,38 @@ Sets a window prop. Can be locked by adding `lock` at the end. If `lock` is not
 added, will be unlocked. Locking means a dynamic windowrule _cannot_ override
 this setting.
 
+Usage:
+```sh
+hyprctl setprop <mode:regex> <property> <value> [lock]
+```
+
+Regex supports different modes. The supported modes are:
+```ini
+class - class
+title - title
+initialclass - initialClass
+initialtitle - initialTitle
+active - active window
+address - address prefixed with 0x
+pid - process ID
+floating - first floating window on the current workspace
+tiled - first tiled window on the current workspace
+```
+
+If no mode is specified `class` is used by default.
+
+{{< callout type=info >}}
+
+To get more information about a window, you can use `hyprctl clients`.
+
+{{< /callout >}}
+
+{{< callout type=warning >}}
+
+Please beware that `hyprctl clients` will display the fields as **initialClass** and **initialTitle** while the regex mode uses `initialclass` and `initialtitle`.
+
+{{< /callout >}}
+
 Prop List:
 | prop | comment |
 | --- | --- |
@@ -228,6 +260,7 @@ Prop List:
 | activebordercolor | gradient, -1 means not set |
 | inactivebordercolor | gradient, -1 means not set |
 
+For example:
 ```sh
 hyprctl setprop address:0x13371337 forcenoanims 1 lock  # with locking
 hyprctl setprop address:0x13371337 nomaxsize 0          # without locking


### PR DESCRIPTION
I was looking for a way to apply window rules to specific windows using their `pid` because dynamic window rules are unusable with the `exec` dispatcher. 
I found out that `hyprctl setprop` actually supports `pid`. This MR adds the missing documentation based on https://github.com/hyprwm/Hyprland/blob/8a68199a0ceb2894a5d9cc300961c38123ac0312/src/Compositor.cpp#L2296-L2386. 
It also explains to users that dynamic window rules do not work with the `exec` dispatcher and points them to `hyprctl setprop`.
See https://github.com/hyprwm/Hyprland/issues/6653