### PR TITLE
Dispatchers: fix typo

### DIFF
--- a/pages/Configuring/Dispatchers.md
+++ b/pages/Configuring/Dispatchers.md
@@ -182,7 +182,7 @@ better, some worse. It records the PID of the spawned process and uses that. For
 your process forks and then the fork opens a window, this will not work.
 Rules will only be applied once. This means dynamic rules will be overridden as soon as a 
 property of the window changes (e.g. switching focus). To make dynamic rules stick around
-use `hyprctl setprop` (see [Using hyprctl](./Using-hyprctl)).
+use `hyprctl setprop` (see [Using hyprctl](../Using-hyprctl)).
 
 The syntax is:
 


### PR DESCRIPTION
@fufexan When submitting https://github.com/hyprwm/hyprland-wiki/pull/696 I thought that referencing would work like this https://github.com/hyprwm/hyprland-wiki/blob/33bd679037ce9bba7a11cd202053f671a4d0414c/pages/Configuring/Dispatchers.md?plain=1#L185 because both files are in the same folder. But as I found out now when I clicked on the link in the wiki it doesn't. 
Is this now correct?