### PR TITLE
Add media keys to example

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -412,4 +412,8 @@ including when the screen is locked:
 bindel=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
 bindel=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 bindl=, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+# Requires playerctl
+bindl=, XF86AudioPlay, exec, playerctl play-pause
+bindl=, XF86AudioPrev, exec, playerctl previous
+bindl=, XF86AudioNext, exec, playerctl next
 ```


### PR DESCRIPTION
The example keybinding for media keys was missing play/pause and skip/back