### PR TITLE
wiki: add screenlocker tty warning

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -117,6 +117,7 @@ update the package. Paru has been problematic with updating before, use Yay.
 ### How do I screen lock?
 
 Use a Wayland-compatible locking utility using WLR protocols, e.g. `swaylock`.
+Be aware that they will not prevent tty-changing using Ctrl-Alt-F1...F7.
 
 ### How do I change me mouse cursor?
 


### PR DESCRIPTION
Hello,

I had my machine configured to have

    full disc encryption,
    auto-login in the console (by setting services.getty.autologinUser = "volker" in my nixos configuration file)
    auto-login in hyprland.

I thought for long that locking the screen with swaylock would be safe in this configuration, since you can't unlock the screen without the password/fingerprint and you cannot reboot without the FDE password.

Then I realized you can still press "Ctrl + Alt + F3" to get a console where you are logged in (due to services.getty.autologinUser) and i.e. download and run a script.

I nearly got a heart attack and I hope you can imagine how I felt.

I hope this warning might save other people from the same mistake.

See also: https://github.com/swaywm/swaylock/issues/365