### PR TITLE
Replace ML4W Dotfiles link from GitLab to GitHub

### DIFF
--- a/pages/Configuring/Example-configurations.md
+++ b/pages/Configuring/Example-configurations.md
@@ -17,7 +17,7 @@ from a more tangible example.
 
 ![](https://i.ibb.co/6ydHNt9/screenshot-29-1.png)
 
-[https://gitlab.com/stephan-raabe/dotfiles](https://gitlab.com/stephan-raabe/dotfiles)
+[https://github.com/mylinuxforwork/dotfiles](https://github.com/mylinuxforwork/dotfiles)
 
 ### fufexan
 


### PR DESCRIPTION
The GitLab repository for the ML4W dotfiles has been archived, as they have been moved to GitHub.