### PR TITLE
Refactor waybar section

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -48,29 +48,19 @@ look like this:
 }
 ```
 
-### Clicking on a workspace icon does not work!
-
-On the `hyprland/workspaces` module, add `"on-click": "activate"`. That's the
-purpose of the `sed` command used before building Waybar: the default way to
-select a workspace by clicking uses `swaymsg`, and thus it is required
-to edit this function to make it work with `hyprctl`.
-
 ### Window title is missing
 
-Follow the above instructions to make sure everything is working. The prefix for
-the window module that provides the title is `hyprland` not `wlr`. In your
-Waybar config, insert this module:
+The prefix for the window module that provides the title is `hyprland` not `wlr`.
+In your Waybar config, insert this module:
 
 ```json
 "modules-center": ["hyprland/window"],
 ```
 
-If you are using a multiple monitors, you may want to also insert this module
-configuration:
+If you are using multiple monitors, you may want to insert the following option:
 
 ```json
 "hyprland/window": {
-    "max-length": 200,
     "separate-outputs": true
 },
 ```


### PR DESCRIPTION
Removed "Clicking on a workspace icon does not work!" section. Click seems working out of the box, and no "on-click" option is present in waybar documentation for that module.
Ref. https://man.archlinux.org/man/extra/waybar/waybar-hyprland-workspaces.5.en Also, no reference to sed and Waybar build process are present.

Removed "max-length" from multiple monitor tip, unrelated.