### PR TITLE
Adding 'Are we Wayland Yet'

### DIFF
--- a/pages/Useful Utilities/Other.md
+++ b/pages/Useful Utilities/Other.md
@@ -65,3 +65,7 @@ This launches `udiskie` and the `&` argument launches it in the
 background.
 
 [See more uses here](https://github.com/coldfix/udiskie/wiki/Usage).
+
+### Other useful utilities
+
+The website [Are we Wayland Yet](https://arewewaylandyet.com/) details some other useful utilities and applications for Wayland like docks, email clients, and so on, along with some other useful information about compatibility on Wayland.


### PR DESCRIPTION
The page is somewhat Hyprland specific but since the main page redirects any former X.Org users to the utilities page, I think we should also include some general utilities and compatibility information. Are we Wayland Yet is one of the better sources I know in this regard. Any questions are welcome.