### PR TITLE
[hyprlock] Add more description for monitor field

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -30,7 +30,7 @@ Variables in the `general` category:
 ## Keyboard Shortcuts and Actions
 
 The following keys and key-combinations describe hyprlock's default behaviour:
-| input | description | 
+| input | description |
 | -- | -- |
 | ESC | Clear password buffer |
 | Ctrl + u | Clear password buffer |
@@ -47,7 +47,16 @@ widget_name {
 }
 ```
 
-`monitor` can be left empty for "all monitors"
+The `monitor` could be either the __port name__ or __description__ value from
+the output of `hyprctl monitors` command. It can be left empty for "all
+monitors"
+
+{{< callout >}}
+
+Pay attention! You do not need to add `desc:` prefix like in
+[`hyprland.conf`](../Configuring/Monitors.md)
+
+{{</ callout >}}
 
 ## Widget List
 


### PR DESCRIPTION
The `monitors` field of hyprlock was not described clearly. Trying to fix that.