### PR TITLE
Add install instructions for Alpine linux

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -240,6 +240,24 @@ For detailed instructions on installing this build see
 
 {{% /details %}}
 
+{{% details title="Alpine*" closed="true" %}}
+
+Hyprland is available in Alpine's [testing repository](https://wiki.alpinelinux.org/wiki/Repositories#Testing) which can be enabled in `/etc/apk/repositories` by adding
+
+```plain
+http://dl-cdn.alpinelinux.org/alpine/edge/testing
+```
+
+This will only work on Alpine linux edge, not on any stable release. For use on stable releases, see the [Alpine wiki](https://wiki.alpinelinux.org/wiki/Repositories#Using_the_testing_repository_on_stable_branches)
+
+After enabling the repository, the following command will install hyprland and its dependencies. 
+
+```plain
+apk add hyprland
+```
+
+{{% /details %}}
+
 _**\* Unofficial, no official support is provided. These instructions are
 community-driven, and no guarantee is provided for their validity.**_
 


### PR DESCRIPTION
Alpine keeps an up-to-date package of hyprland in its testing repository.