### PR TITLE
Use plasma-polkit-agent.service rather than launching directly

### DIFF
--- a/pages/Useful Utilities/Must-have.md
+++ b/pages/Useful Utilities/Must-have.md
@@ -59,9 +59,15 @@ Our recommendation is the KDE one. For arch, it's `polkit-kde-agent`.
 You can autostart it with
 `exec-once=systemctl --user start plasma-polkit-agent`.
 
-On other distributions that use a different init system, such as Gentoo, it may be
+On distributions that use a different init system, such as Gentoo, it may be
 necessary to use
 `exec-once=/usr/lib64/libexec/polkit-kde-authentication-agent-1` instead.
+
+Other possible paths include
+`/usr/lib/polkit-kde-authentication-agent-1`,
+`/usr/libexec/polkit-kde-authentication-agent-1`,
+`/usr/libexec/kf5/polkit-kde-authentication-agent-1`, and
+`/usr/libexec/kf6/polkit-kde-authentication-agent-1`.
 
 ### Qt Wayland Support
 

--- a/pages/Useful Utilities/Must-have.md
+++ b/pages/Useful Utilities/Must-have.md
@@ -57,13 +57,9 @@ password whenever an app wants to elevate its privileges.
 Our recommendation is the KDE one. For arch, it's `polkit-kde-agent`.
 
 You can autostart it with
-`exec-once=/usr/lib/polkit-kde-authentication-agent-1`. On some distributions
-you might have to use a different path which could be
-`/ usr/libexec/polkit-kde-authentication-agent-1`,
-`/usr/libexec/kf5/polkit-kde-authentication-agent-1`, or
-`/usr/libexec/kf6/polkit-kde-authentication-agent-1`.
+`exec-once=systemctl --user start plasma-polkit-agent`
 
-On other distributions that use a more recent version, such as Gentoo, it may be
+On other distributions that use a different init system, such as Gentoo, it may be
 necessary to use
 `exec-once=/usr/lib64/libexec/polkit-kde-authentication-agent-1` instead.
 

--- a/pages/Useful Utilities/Must-have.md
+++ b/pages/Useful Utilities/Must-have.md
@@ -57,7 +57,7 @@ password whenever an app wants to elevate its privileges.
 Our recommendation is the KDE one. For arch, it's `polkit-kde-agent`.
 
 You can autostart it with
-`exec-once=systemctl --user start plasma-polkit-agent`
+`exec-once=systemctl --user start plasma-polkit-agent`.
 
 On other distributions that use a different init system, such as Gentoo, it may be
 necessary to use


### PR DESCRIPTION
This works regardless of where `polkit-kde-authentication-agent-1` is stored and also allows the service to be stopped if needed for whatever reason.

Also change instructions to refer to different init systems rather than different locations for the executable.