### PR TITLE
fix broken link from Hyprcursor Page to FAQ.

### DIFF
--- a/pages/Hypr Ecosystem/hyprcursor.md
+++ b/pages/Hypr Ecosystem/hyprcursor.md
@@ -64,4 +64,4 @@ whatever you define with `XCURSOR_THEME` and `XCURSOR_SIZE`.
 
 ## My cursor is a hyprland icon?
 
-See [FAQ](../FAQ)
+See [FAQ](../../FAQ)


### PR DESCRIPTION
Makes hyprcursor FAQ redirect goto ../../FAQ instead of ../FAQ (previous one redirected to a nonexistant FAQ page in the Hypr Ecosystem directory)