### PR TITLE
Mention the use of dconf to fix errors with gtk themes, since gsettings doesn't work and is what the sway devs suggest

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -147,7 +147,7 @@ in {
 If your themes for mouse cursors, icons or windows don't load correctly, see the
 relevant section in [Hyprland on Home Manager](../Hyprland-on-Home-Manager).
 
-If you prefer not to use home manager, you can also resolve the issues with GTK themes using dconf like so:
+If you prefer not to use Home Manager, you can also resolve the issues with GTK themes using dconf like so:
 
 exec-once = dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"
 exec-once = dconf write /org/gnome/desktop/interface/icon-theme "'Flat-Remix-Red-Dark'"

--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -147,10 +147,13 @@ in {
 If your themes for mouse cursors, icons or windows don't load correctly, see the
 relevant section in [Hyprland on Home Manager](../Hyprland-on-Home-Manager).
 
-If you prefer not to use Home Manager, you can also resolve the issues with GTK themes using dconf like so:
+If you prefer not to use Home Manager, you can also resolve the issues with GTK
+themes using dconf like so:
 
+```ini
 exec-once = dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"
 exec-once = dconf write /org/gnome/desktop/interface/icon-theme "'Flat-Remix-Red-Dark'"
 exec-once = dconf write /org/gnome/desktop/interface/document-font-name "'Noto Sans Medium 11'"
 exec-once = dconf write /org/gnome/desktop/interface/font-name "'Noto Sans Medium 11'"
 exec-once = dconf write /org/gnome/desktop/interface/monospace-font-name "'Noto Sans Mono Medium 11'"
+```

--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -146,3 +146,11 @@ in {
 
 If your themes for mouse cursors, icons or windows don't load correctly, see the
 relevant section in [Hyprland on Home Manager](../Hyprland-on-Home-Manager).
+
+If you prefer not to use home manager, you can also resolve the issues with GTK themes using dconf like so:
+
+exec-once = dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"
+exec-once = dconf write /org/gnome/desktop/interface/icon-theme "'Flat-Remix-Red-Dark'"
+exec-once = dconf write /org/gnome/desktop/interface/document-font-name "'Noto Sans Medium 11'"
+exec-once = dconf write /org/gnome/desktop/interface/font-name "'Noto Sans Medium 11'"
+exec-once = dconf write /org/gnome/desktop/interface/monospace-font-name "'Noto Sans Mono Medium 11'"


### PR DESCRIPTION
Literally spent hours trying to use gsettings like sway suggests before I found it gsettings just doesn't work properly on nixos and you need to use dconf.

If this was written here it would've saved me so much time.