### PR TITLE
updated wiki for Ubuntu installation

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -180,7 +180,9 @@ sudo add-apt-repository universe && sudo apt-get update && sudo apt-get install 
 ```
 
 {{< callout type=info >}}
+
 NOTE: Above is for Ubuntu 24.10 (Unreleased) version
+
 {{< /callout >}}
 
 For installing Hyprland from Source, install first the dependencies below:
@@ -191,6 +193,20 @@ sudo apt-get install -y meson wget build-essential ninja-build cmake-extras cmak
 
 you will also need to build the latest wayland, wayland-protocols, and
 libdisplay-info tagged releases from source
+
+For screensharing, you can install also install xdg-desktop-portal-wlr or xdg-desktop-portal-hyprland 
+```bash
+sudo apt-get install -y xdg-desktop-portal-wlr
+```
+
+_Unfortunately, `xdg-desktop-portal-hyprland` still not in Ubuntu Repo so you have to build it from source_
+
+See
+[The xdph Github repo's readme](https://github.com/hyprwm/xdg-desktop-portal-hyprland).
+
+Refer to
+[XDPH](../../Hypr-Ecosystem/xdg-desktop-portal-hyprland) for more information
+
 
 for more info refer to the
 [Ubuntu Guide For Installing And Building Hyprland Gist](https://gist.github.com/Vertecedoc4545/3b077301299c20c5b9b4db00f4ca6000)

--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -178,8 +178,10 @@ Hyprland made it into the Ubuntu 24.10 Oracular Oriole universe repo and can be 
 ```bash
 sudo add-apt-repository universe && sudo apt-get update && sudo apt-get install -y hyprland
 ```
-> [!NOTE]
-> Above is for Ubuntu 24.10 (Unreleased) version
+
+{{< callout type=info >}}
+NOTE: Above is for Ubuntu 24.10 (Unreleased) version
+{{< /callout >}}
 
 For installing Hyprland from Source, install first the dependencies below:
 

--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -174,14 +174,17 @@ Hyprland and related are in the default repository:
 
 {{% details title="Ubuntu*" closed="true" %}}
 
-Hyprland made it into the universe repos and can be installed with 
+Hyprland made it into the Ubuntu 24.10 Oracular Oriole universe repo and can be installed with 
 ```bash
 sudo add-apt-repository universe && sudo apt-get update && sudo apt-get install -y hyprland
 ```
-Build dependencies:
+> [!NOTE]
+> Above is for Ubuntu 24.10 (Unreleased) version
+
+For installing Hyprland from Source, install first the dependencies below:
 
 ```bash
-sudo apt-get install -y meson wget build-essential ninja-build cmake-extras cmake gettext gettext-base fontconfig libfontconfig-dev libffi-dev libxml2-dev libdrm-dev libxkbcommon-x11-dev libxkbregistry-dev libxkbcommon-dev libpixman-1-dev libudev-dev libseat-dev seatd libxcb-dri3-dev libegl-dev libgles2 libegl1-mesa-dev glslang-tools libinput-bin libinput-dev libxcb-composite0-dev libavutil-dev libavcodec-dev libavformat-dev libxcb-ewmh2 libxcb-ewmh-dev libxcb-present-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-res0-dev libxcb-xinput-dev xdg-desktop-portal-wlr libtomlplusplus3
+sudo apt-get install -y meson wget build-essential ninja-build cmake-extras cmake gettext gettext-base fontconfig libfontconfig-dev libffi-dev libxml2-dev libdrm-dev libxkbcommon-x11-dev libxkbregistry-dev libxkbcommon-dev libpixman-1-dev libudev-dev libseat-dev seatd libxcb-dri3-dev libegl-dev libgles2 libegl1-mesa-dev glslang-tools libinput-bin libinput-dev libxcb-composite0-dev libavutil-dev libavcodec-dev libavformat-dev libxcb-ewmh2 libxcb-ewmh-dev libxcb-present-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-res0-dev libxcb-xinput-dev libtomlplusplus3
 ```
 
 you will also need to build the latest wayland, wayland-protocols, and

--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -194,7 +194,8 @@ sudo apt-get install -y meson wget build-essential ninja-build cmake-extras cmak
 you will also need to build the latest wayland, wayland-protocols, and
 libdisplay-info tagged releases from source
 
-For screensharing, you can install also install xdg-desktop-portal-wlr or xdg-desktop-portal-hyprland 
+For screensharing, you can also `install xdg-desktop-portal-wlr` or `xdg-desktop-portal-hyprland`
+
 ```bash
 sudo apt-get install -y xdg-desktop-portal-wlr
 ```
@@ -206,7 +207,6 @@ See
 
 Refer to
 [XDPH](../../Hypr-Ecosystem/xdg-desktop-portal-hyprland) for more information
-
 
 for more info refer to the
 [Ubuntu Guide For Installing And Building Hyprland Gist](https://gist.github.com/Vertecedoc4545/3b077301299c20c5b9b4db00f4ca6000)


### PR DESCRIPTION
Updated wiki for installing hyprland in ubuntu.

To clarify that Hyprland made it to Ubuntu 24.10 (Unrealeased) universe repo