### PR TITLE
chore: yay command without sudo

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -41,7 +41,7 @@ from source first.
 
 Install from the AUR, which compiles the latest source:
 ```shell
-sudo yay -S hyprland-git
+yay -S hyprland-git
 ```
 
 or a tagged release from the arch packages:


### PR DESCRIPTION
When running yay with sudo, it shows a funny warn `-> Avoid running yay as root/sudo.`. But then it still continues the installtion and run `makepkg` as root and causes error `Running makepkg as root is not allowed`. 