### PR TITLE
Update Status-Bars.md to fix an eww widget class problem

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -123,8 +123,8 @@ workspaces. It requires [bash](https://linux.die.net/man/1/bash),
       (label :text "${workspaces}${current_workspace}" :visible false)
       (for workspace in workspaces
         (eventbox :onclick "hyprctl dispatch workspace ${workspace.id}"
-          (box :class "workspace-entry ${workspace.id == current_workspace ? "current" : ""} ${workspace.windows > 0 ? "occupied" : "empty"}"
-            (label :text "${workspace.id}")
+          (box :class "workspace-entry ${workspace.windows > 0 ? "occupied" : "empty"}"
+            (label :text "${workspace.id}" :class "workspace-entry ${workspace.id == current_workspace ? "current" : ""}" )
             )
           )
         )


### PR DESCRIPTION
Hi, i noticed that the eww widget example for building a status bar, has a problem with the "current" class

example: using this scss code:
``` scss
// workspaces 

.current{
  color: $bright_yellow;

}

.occupied {
  color: $magenta;

}

.empty {
  color: #ffffff ;
}

```
and using the default eww yuck code:
``` lisp
 (box :class "workspace-entry ${workspace.id == current_workspace ? "current" : ""} ${workspace.windows > 0 ? "occupied" : "empty"}"
            (label :text "${workspace.id == current_workspace ? "󰜋" : "󰜌"}"    ;; characters are rhomboids                
            )
) 
```
Generates this bar 
![image](https://github.com/user-attachments/assets/9a356f21-af57-4c08-99ff-03e8091be074)
as you can see the "current" class its overwritten by the "occupied" class (same happens with "empty" class), there is no bright yellow color on it.

to fix this we can add another class to the label widget and remove the class from the box widget:
``` lisp
(box :class "workspace-entry ${workspace.windows > 0 ? "occupied" : "empty"}"
            (label :text "${workspace.id == current_workspace ? "󰜋" : "󰜌"}"     ;; characters are rhomboids  
                       :class "workspace-entry ${workspace.id == current_workspace ? "current" : ""}"
            ) 
)
```
the result: 
![image](https://github.com/user-attachments/assets/6bfb84b7-dda3-49fc-b211-1f87ee4b0d52)
as you can see now the "current" class is working and we have bright yellow color.
