### PR TITLE
dwindle: add a description for the config option `split_bias`

### DIFF
--- a/pages/Configuring/Dwindle-Layout.md
+++ b/pages/Configuring/Dwindle-Layout.md
@@ -29,6 +29,7 @@ category name: `dwindle`
 | no_gaps_when_only | whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 [0/1/2] | int | 0 |
 | use_active_for_splits | whether to prefer the active window or the mouse position for splits | bool | true |
 | default_split_ratio | the default split ratio on window open. 1 means even 50/50 split. [0.1 - 1.9] | float | 1.0 |
+| split_bias | specifies which window will receive the larger half of a split. positional - 0, current window - 1, opening window - 2 [0/1/2] | int | 0 |
 
 ## Bind Dispatchers
 


### PR DESCRIPTION
Related to this pull request: https://github.com/hyprwm/Hyprland/pull/7920