### PR TITLE
Links between Variables and WindowRules for renderunfocused

### DIFF
--- a/pages/Configuring/Using-hyprctl.md
+++ b/pages/Configuring/Using-hyprctl.md
@@ -95,7 +95,9 @@ Usage:
 ```sh
 hyprctl output create [backend] (name)
 ```
+
 or
+
 ```sh
 hyprctl output remove [name]
 ```
@@ -110,7 +112,8 @@ used (`HEADLESS-2`, `WL-1`, etc.)
 
 {{< /callout >}}
 
-Available backends: 
+Available backends:
+
 - `wayland`: Creates an output as a Wayland window. This will only work if
   you're already running Hyprland with the Wayland backend.
 - `headless`: Creates a headless monitor output. If you're running a VNC/RDP/
@@ -199,11 +202,13 @@ added, will be unlocked. Locking means a dynamic windowrule _cannot_ override
 this setting.
 
 Usage:
+
 ```sh
 hyprctl setprop <mode:regex> <property> <value> [lock]
 ```
 
 Regex supports different modes. The supported modes are:
+
 ```ini
 class - class
 title - title
@@ -233,6 +238,7 @@ and **initialTitle** while the regex mode uses `initialclass` and
 {{< /callout >}}
 
 Prop List:
+
 | prop | comment |
 | --- | --- |
 | alpha | float 0.0 - 1.0 |
@@ -250,6 +256,7 @@ Prop List:
 Additional properties can be found in the [Window Rules](../Window-Rules#dynamic-rules) section.
 
 For example:
+
 ```sh
 hyprctl setprop address:0x13371337 noanim 1
 hyprctl setprop address:0x13371337 nomaxsize 0
@@ -277,7 +284,7 @@ Color of `0` means "Default color for icon"
 
 Icon list:
 
-```
+```sh
 WARNING = 0
 INFO = 1
 HINT = 2

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -173,11 +173,11 @@ _[More about Animations](../Animations)._
 | repeat_rate | The repeat rate for held-down keys, in repeats per second. | int | 25 |
 | repeat_delay | Delay before a held-down key is repeated, in milliseconds. | int | 600 |
 | sensitivity | Sets the mouse input sensitivity. Value is clamped to the range -1.0 to 1.0. [libinput#pointer-acceleration](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration) | float | 0.0 |
-| accel_profile | Sets the cursor acceleration profile. Can be one of `adaptive`, `flat`. Can also be `custom`, see [below](#custom-accel-profiles). Leave empty to use `libinput`'s default mode for your input device. [libinput#pointer-acceleration](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration) [adaptive/flat/custom]| str | \[\[Empty\]\]
+| accel_profile | Sets the cursor acceleration profile. Can be one of `adaptive`, `flat`. Can also be `custom`, see [below](#custom-accel-profiles). Leave empty to use `libinput`'s default mode for your input device. [libinput#pointer-acceleration](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration) [adaptive/flat/custom]| str | \[\[Empty\]\] |
 | force_no_accel | Force no cursor acceleration. This bypasses most of your pointer settings to get as raw of a signal as possible. **Enabling this is not recommended due to potential cursor desynchronization.** | bool | false |
 | left_handed | Switches RMB and LMB | bool | false |
-| scroll_points | Sets the scroll acceleration profile, when `accel_profile` is set to `custom`. Has to be in the form `<step> <points>`. Leave empty to have a flat scroll curve. | str | \[\[Empty\]\]
-| scroll_method | Sets the scroll method. Can be one of `2fg` (2 fingers), `edge`, `on_button_down`, `no_scroll`. [libinput#scrolling](https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html) [2fg/edge/on_button_down/no_scroll] | str | \[\[Empty\]\]
+| scroll_points | Sets the scroll acceleration profile, when `accel_profile` is set to `custom`. Has to be in the form `<step> <points>`. Leave empty to have a flat scroll curve. | str | \[\[Empty\]\] |
+| scroll_method | Sets the scroll method. Can be one of `2fg` (2 fingers), `edge`, `on_button_down`, `no_scroll`. [libinput#scrolling](https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html) [2fg/edge/on_button_down/no_scroll] | str | \[\[Empty\]\] |
 | scroll_button | Sets the scroll button. Has to be an int, cannot be a string. Check `wev` if you have any doubts regarding the ID. 0 means default. | int | 0 |
 | scroll_button_lock | If the scroll button lock is enabled, the button does not need to be held down. Pressing and releasing the button toggles the button lock, which logically holds the button down or releases it. While the button is logically held down, motion events are converted to scroll events. | bool | 0 |
 | scroll_factor | Multiplier added to scroll movement for external mice. Note that there is a separate setting for [touchpad scroll_factor](#touchpad).  | float | 1.0 |
@@ -370,7 +370,7 @@ _Subcategory `group:groupbar:`_
 | exit_window_retains_fullscreen | if true, closing a fullscreen window makes the next focused window fullscreen | bool | false |
 | initial_workspace_tracking | if enabled, windows will open on the workspace they were invoked on. 0 - disabled, 1 - single-shot, 2 - persistent (all children too) | int | 1 |
 | middle_click_paste | whether to enable middle-click-paste (aka primary selection) | bool | true |
-| render_unfocused_fps | the maximum limit for renderunfocused windows' fps in the background | int | 15 |
+| render_unfocused_fps | the maximum limit for renderunfocused windows' fps in the background (see also [Window-Rules](../Window-Rules/#dynamic-rules) - `renderunfocused`)| int | 15 |
 | disable_xdg_env_checks | disable the warning if XDG environment is externally managed | bool | false |
 
 ### Binds

--- a/pages/Configuring/Window-Rules.md
+++ b/pages/Configuring/Window-Rules.md
@@ -314,7 +314,7 @@ where `rule` is the rule and `namespace` is the namespace regex (find
 namespaces in `hyprctl layers`) or `address` is an address in the form of
 `address:0x[hex]`.
 
-### List of Rules
+### Rules
 
 | rule | description |
 | --- | --- |

--- a/pages/Configuring/Window-Rules.md
+++ b/pages/Configuring/Window-Rules.md
@@ -119,7 +119,6 @@ Static rules are evaluated once when the window is opened and never again.
 | group \[options\] | set window group properties. See the note below. |
 | suppressevent \[types...\] | ignores specific events from the window. Events are space separated, and can be: `fullscreen` `maximize` `activate` `activatefocus` |
 
-
 ### Dynamic rules
 
 Dynamic rules are re-evaluated every time a property changes.
@@ -160,7 +159,7 @@ The following rules can also be set with [`hyprctl setprop`](../Using-hyprctl#se
 | syncfullscreen \[on\] | whether the fullscreen mode should always be the same as the one sent to the window (will only take effect on the next fullscreen mode change) |
 | immediate \[on\] | forces the window to allow to be torn. See [the Tearing page](../Tearing). |
 | xray \[on\] | sets blur xray mode for the window |
-| renderunfocused | forces the window to think it's being rendered when it's not visible |
+| renderunfocused | forces the window to think it's being rendered when it's not visible - see also [Variables - Misc](../Variables/#Misc) for setting ``render_unfocused_fps`` |
 
 When using window rules, \[on\] can be set to `0` for off, `1` for on or not set
 for default.
@@ -237,7 +236,6 @@ windowrulev2 = opacity 0.4 override, tag:alpha_0.4
 The `tag` rule can only manipulate dynamic tags, and the `tagwindow` dispatcher
 only work with static tags (as once the dispatcher is called, dynamic tags will
 be cleared).
-
 
 ### Example Rules
 
@@ -316,7 +314,7 @@ where `rule` is the rule and `namespace` is the namespace regex (find
 namespaces in `hyprctl layers`) or `address` is an address in the form of
 `address:0x[hex]`.
 
-### Rules
+### List of Rules
 
 | rule | description |
 | --- | --- |


### PR DESCRIPTION
also some minor linting in Variables.md and Window-Rules.md
https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md055.md
https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md031.md

Added sh as language for IconList, so linter wouldnt throw a warning.