### PR TITLE
Specified bad XDG env could break desktop portal

### DIFF
--- a/pages/Configuring/Environment-variables.md
+++ b/pages/Configuring/Environment-variables.md
@@ -69,6 +69,9 @@ XDG specific environment variables are often detected through portals and
 applications that may set those for you, however it is not a bad idea to set
 them explicitly.
 
+If your [desktop portal](https://wiki.archlinux.org/title/XDG_Desktop_Portal) is malfunctioning for seemingly
+no reason (no errors), it's likely your XDG env isn't set correctly.
+
 ## Qt Variables
 
 - `env = QT_AUTO_SCREEN_SCALE_FACTOR,1` -

--- a/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
+++ b/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
@@ -173,6 +173,10 @@ logs.
 If you see a crash, it's likely you are missing either `qt6-wayland` or
 `qt5-wayland`.
 
+If the portal does not autostart, does not function when manually started, 
+and does not produce any error logs, it's very likely your [XDG env variables](../../Configuring/Environment-variables.md/#xdg-specifications)
+are messed up
+
 ## Configuration
 
 Example:


### PR DESCRIPTION
I've recently encountered a seemingly not very well documented issue of bad XDG env breaking desktop portal. I specified said issue in wiki so others can have an easier time dealing with this issue