### PR TITLE
IPC: fix example

### DIFF
--- a/pages/IPC/_index.md
+++ b/pages/IPC/_index.md
@@ -62,7 +62,7 @@ e.g.: `workspace>>2`
 | screencast | emitted when a screencopy state of a client changes. Keep in mind there might be multiple separate clients. State is 0/1, owner is 0 - monitor share, 1 - window share | `STATE,OWNER` |
 | windowtitle | emitted when a window title changes. | `WINDOWADDRESS` |
 | windowtitlev2 | emitted when a window title changes. | `WINDOWADDRESS,WINDOWTITLE` |
-| togglegroup | emitted when `togglegroup` command is used. <br> returns `state,handle` where the `state` is a toggle status and the `handle` is one or more window addresses separated by a comma<br> e.g. `0,0x64cea2525760,0x64cea2522380` where `0` means that a group has been destroyed and the rest informs which windows were part of it | `0/1,WINDOWADDRESS(ES)` |
+| togglegroup | emitted when `togglegroup` command is used. <br> returns `state,handle` where the `state` is a toggle status and the `handle` is one or more window addresses separated by a comma<br> e.g. `0,64cea2525760,64cea2522380` where `0` means that a group has been destroyed and the rest informs which windows were part of it | `0/1,WINDOWADDRESS(ES)` |
 | moveintogroup | emitted when the window is merged into a group. returns the address of a merged window | `WINDOWADDRESS` |
 | moveoutofgroup | emitted when the window is removed from a group. returns the address of a removed window | `WINDOWADDRESS` |
 | ignoregrouplock | emitted when `ignoregrouplock` is toggled. | `0/1` |


### PR DESCRIPTION
Doesn't look like the output includes 0x prefixes:

```
activewindow>>kitty,nagumo: ~
activewindowv2>>56bc4fa2d270
togglegroup>>0,56bc4fa2d270
windowtitle>>56bc4fa2d270
windowtitlev2>>56bc4fa2d270,nagumo $ hyprctl dispatch togglegroup
```

(hyprland-git 0.43.0.r89.5c6c300a-1)