### PR TITLE
add newline

### DIFF
--- a/pages/Useful Utilities/Clipboard-Managers.md
+++ b/pages/Useful Utilities/Clipboard-Managers.md
@@ -9,6 +9,7 @@ Clipboard Managers provide a convenient way to organize and access previously
 copied content, including both text and images.
 
 Some common ones used are `cb`, `copyq`, `clipman`, `cliphist` and `clipse`.
+
 `cb` - Utilizes Wayland and stores text, images and files temporarily or 
 indefinitely. Allows unlimited clipboards and history, JSON output and more.
 [GitHub](https://github.com/Slackadays/Clipboard)


### PR DESCRIPTION
Corrects the formatting issue, where the 2 sentences are sown in the same line

![image](https://github.com/user-attachments/assets/73b14764-ee0b-4b50-897a-71972f09b8e7)
