### PR TITLE
include smart gaps for maximised windows

### DIFF
--- a/pages/Configuring/Workspace-Rules.md
+++ b/pages/Configuring/Workspace-Rules.md
@@ -55,10 +55,17 @@ workspace = w[tg1-4], shadow:false
 
 #### Smart gaps
 
-To replicate "smart gaps" / "no gaps when only", from other WMs/Compositors, use
+To replicate "smart gaps" / "no gaps when only" from other WMs/Compositors, use
 
 ```ini
-workspace = w[tg1], gapsout:0, border: 0, rounding:0
+workspace = w[t1], gapsout:0, gapsin:0, border: 0, rounding:0
+workspace = w[tg1], gapsout:0, gapsin:0, border: 0, rounding:0
+```
+
+If you want no gaps when a window is maximised (but not fullscreen), add this rule as well
+
+```ini
+workspace = f[1], gapsout:0, gapsin:0, border: 0, rounding:0
 ```
 
 ## Rules


### PR DESCRIPTION
Having smart gaps on maximised windows was the behavior of the original `no_gaps_when_only`.
Additionally, it appears that the `w[tg1]` selector does not work. That has been changed to `w[t1]`.