### PR TITLE
Uncommon tips and tricks: new section to reset F13-F24

### DIFF
--- a/pages/Configuring/Uncommon-tips-&-tricks.md
+++ b/pages/Configuring/Uncommon-tips-&-tricks.md
@@ -82,6 +82,24 @@ input {
     kb_options = caps:swapescape
 }
 ```
+
+## Set F13-F24 as usual function keys
+By default, F13-F24 are mapped by xkb as various "XF86" keysyms. These cause binding
+issues in many programs. One example is OBS Studio, which does not detect the XF86
+keysyms as usable keybindings, making you unable to use them for binds, This option
+simply maps them back to the expected F13-F24 values, which are bindable as normal.
+
+{{< callout >}}
+This option was only added recently to `xkeyboard-config`. Please ensure you are on version
+2.43 or greater for this option to do anything.
+{{< /callout >}}
+
+```
+input {
+    kb_options = fkeys:basic_13-24
+}
+```
+
 ##  Minimize windows using special workspaces
 This approach uses special workspaces to mimic the "minimize window" function, by using a single keybind to toggle the minimized state.
 Note that one keybind can only handle one window.

--- a/pages/Configuring/Uncommon-tips-&-tricks.md
+++ b/pages/Configuring/Uncommon-tips-&-tricks.md
@@ -86,7 +86,7 @@ input {
 ## Set F13-F24 as usual function keys
 By default, F13-F24 are mapped by xkb as various "XF86" keysyms. These cause binding
 issues in many programs. One example is OBS Studio, which does not detect the XF86
-keysyms as usable keybindings, making you unable to use them for binds, This option
+keysyms as usable keybindings, making you unable to use them for binds. This option
 simply maps them back to the expected F13-F24 values, which are bindable as normal.
 
 {{< callout >}}


### PR DESCRIPTION
This PR adds a simple section to the wiki which explains how to reset the F13-F24 keys from their XF86 keysyms back to their expected F13-F24 ones. These are then bindable in programs like OBS.

Please let me know if you have any issues with addition.