### PR TITLE
hyprlock: Clarify that XDG env can affect the fade out behavior.

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -27,6 +27,12 @@ Variables in the `general` category:
 | text_trim | sets if the text should be trimmed, useful to avoid trailing newline in commands output | bool | true |
 | fractional_scaling | whether to use fractional scaling. 0 - disabled, 1 - enabled, 2 - auto | int | 2 |
 
+{{< callout type=warning >}}
+
+If you are not on hyprland, or your  `XDG_CURRENT_DESKTOP` is not Hyprland, the fade out will be disabled and the value of your `no_fade_out` variable will be ignored.
+
+{{< /callout >}}
+
 ## Keyboard Shortcuts and Actions
 
 The following keys and key-combinations describe hyprlock's default behaviour:


### PR DESCRIPTION
Having a badly set XDG env variable is currently quite confusing as there is no indication this affects the way hyprlock fades out (but not in).

See hyprwm/hyprlock#521