### PR TITLE
Update documentation for hyprpaper

### DIFF
--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -5,31 +5,6 @@ title: hyprpaper
 
 hyprpaper is a fast, IPC-controlled wallpaper utility for Hyprland.
 
-## Installation
-
-### [Arch Linux Install](https://archlinux.org/packages/extra/x86_64/hyprpaper/)
-
-```sh
-pacman -S hyprpaper
-```
-
-### [OpenSuse Linux Install](https://software.opensuse.org/package/hyprpaper)
-
-```sh
-zypper install hyprpaper
-```
-
-### Manual
-
-For manual installation please check the [docs](https://github.com/hyprwm/hyprpaper?tab=readme-ov-file#manual)
-
-
-## Run at startup
-
-To run hyprpaper at startup edit `hyprland.conf` and add: `exec-once =
-hyprpaper`.
-
-
 ## Configuration
 
 The config file is located at `~/.config/hypr/hyprpaper.conf`. It is not
@@ -66,6 +41,11 @@ Also you can use `reload` to unload preloaded image from your monitor(s),
 preload another and set it to your monitor(s). It has the same syntax as
 `wallpaper` keyword.
 
+### Run at startup
+
+To run hyprpaper at startup edit `hyprland.conf` and add: `exec-once =
+hyprpaper`.
+
 ### Misc options
 
 | variable | description | type | default |
@@ -96,6 +76,3 @@ hyprctl hyprpaper listloaded
 ```
 
 Please note all paths have to be absolute (or start with `~`).
-
-## Docs
-If you want to know more you can read the [docs](https://github.com/hyprwm/hyprpaper?tab=readme-ov-file#hyprpaper)

--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -5,6 +5,31 @@ title: hyprpaper
 
 hyprpaper is a fast, IPC-controlled wallpaper utility for Hyprland.
 
+## Installation
+
+### [Arch Linux Install](https://archlinux.org/packages/extra/x86_64/hyprpaper/)
+
+```sh
+pacman -S hyprpaper
+```
+
+### [OpenSuse Linux Install](https://software.opensuse.org/package/hyprpaper)
+
+```sh
+zypper install hyprpaper
+```
+
+### Manual
+
+For manual installation please check the [docs](https://github.com/hyprwm/hyprpaper?tab=readme-ov-file#manual)
+
+
+## Run at startup
+
+To run hyprpaper at startup edit `hyprland.conf` and add: `exec-once =
+hyprpaper`.
+
+
 ## Configuration
 
 The config file is located at `~/.config/hypr/hyprpaper.conf`. It is not
@@ -41,9 +66,6 @@ Also you can use `reload` to unload preloaded image from your monitor(s),
 preload another and set it to your monitor(s). It has the same syntax as
 `wallpaper` keyword.
 
-To run hyprpaper at startup edit `hyprland.conf` and add: `exec-once =
-hyprpaper`.
-
 ### Misc options
 
 | variable | description | type | default |
@@ -74,3 +96,6 @@ hyprctl hyprpaper listloaded
 ```
 
 Please note all paths have to be absolute (or start with `~`).
+
+## Docs
+If you want to know more you can read the [docs](https://github.com/hyprwm/hyprpaper?tab=readme-ov-file#hyprpaper)

--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -5,6 +5,81 @@ title: hyprpaper
 
 hyprpaper is a fast, IPC-controlled wallpaper utility for Hyprland.
 
+## Installation
+
+{{% details title="Arch" closed="true" %}}
+
+```sh
+pacman -S hyprpaper
+```
+
+{{% /details %}}
+
+{{% details title="OpenSuse" closed="true" %}}
+
+```sh
+zypper install hyprpaper
+```
+
+{{% /details %}}
+
+{{% details title="Fedora" closed="true" %}}
+
+```sh
+sudo dnf install hyprpaper
+```
+
+{{% /details %}}
+
+
+{{% details title="Manual" closed="true" %}}
+### Dependencies
+The development files of these packages need to be installed on the system for `hyprpaper` to build correctly.
+(Development packages are usually suffixed with `-dev` or `-devel` in most distros' repos).
+- wayland
+- wayland-protocols
+- pango
+- cairo
+- file
+- libglvnd
+- libglvnd-core
+- libjpeg-turbo
+- libwebp
+- hyprlang
+- hyprutils
+- hyprwayland-scanner
+
+To install all of these in Fedora, run this command:
+```
+sudo dnf install wayland-devel wayland-protocols-devel hyprlang-devel pango-devel cairo-devel file-devel libglvnd-devel libglvnd-core-devel libjpeg-turbo-devel libwebp-devel gcc-c++ hyprutils-devel hyprwayland-scanner
+```
+
+On Arch:
+```
+sudo pacman -S ninja gcc wayland-protocols libjpeg-turbo libwebp pango cairo pkgconf cmake libglvnd wayland hyprutils hyprwayland-scanner hyprlang
+```
+
+On OpenSUSE:
+```
+sudo zypper install ninja gcc-c++ wayland-protocols-devel Mesa-libGLESv3-devel file-devel hyprutils-devel hyprwayland-scanner
+```
+
+### Building
+
+Building is done via CMake:
+
+```sh
+cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
+cmake --build ./build --config Release --target hyprpaper -j`nproc 2>/dev/null || getconf _NPROCESSORS_CONF`
+```
+
+Install with:
+
+```sh
+cmake --install ./build
+```
+{{% /details %}}
+
 ## Configuration
 
 The config file is located at `~/.config/hypr/hyprpaper.conf`. It is not

--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -33,6 +33,7 @@ sudo dnf install hyprpaper
 
 
 {{% details title="Manual" closed="true" %}}
+
 ### Dependencies
 The development files of these packages need to be installed on the system for `hyprpaper` to build correctly.
 (Development packages are usually suffixed with `-dev` or `-devel` in most distros' repos).
@@ -78,6 +79,7 @@ Install with:
 ```sh
 cmake --install ./build
 ```
+
 {{% /details %}}
 
 ## Configuration


### PR DESCRIPTION
### What was done?

-  Added an Installation section to avoid having to visit the Hyprpaper repo if you are on the webpage.
-  Moved the "Run at startup" note to its own section for better visibility.
-  Added a Docs section to link the Hyprpaper repo to the webpage.