### PR TITLE
Fix 404 in master tutorial

### DIFF
--- a/pages/Getting Started/Master-Tutorial.md
+++ b/pages/Getting Started/Master-Tutorial.md
@@ -106,7 +106,7 @@ repository for a more comprehensive list.
 ## Fully configure Hyprland
 
 Head onto the
-[Configuring Hyprland page](../../Configuring/Configuring-Hyprland) to learn all
+[Configuring Hyprland page](../../Configuring) to learn all
 about configuring Hyprland to your liking.
 
 ## Cursors


### PR DESCRIPTION
Link previously led to https://wiki.hyprland.org/Configuring/Configuring-Hyprland which doesn't exist. 
I think it was meant to point to https://wiki.hyprland.org/Configuring instead.