### PR TITLE
Notification-daemon - add info about D-Bus activation.

### DIFF
--- a/pages/Useful Utilities/Must-have.md
+++ b/pages/Useful Utilities/Must-have.md
@@ -11,11 +11,11 @@ not, as you might want to use something else.
 
 ### A notification daemon
 
-_Starting method:_ most likely manual (`exec-once`)
+_Starting method:_ Automatically, via D-Bus activation, when a notification is emmitted. Alternatively, `exec-once` entry inside `hyprland.conf` can be used. The latter might be preferable, if there are several notification daemons installed on your system.
 
 Many apps (e.g. Discord) may freeze without one running.
 
-Examples: `dunst`, `mako`, and `swaync`.
+Examples: `dunst`, `mako`, `fnott` and `swaync`.
 
 ### Pipewire
 


### PR DESCRIPTION
Most popular notification daemons (namely, dunst, mako, fnott) start automatically via D-Bus activation, whenever a notification is emitted. This is a preferable method, as it allows delaying the daemon startup, until needed, thus slightly speeding up startup.

See https://github.com/emersion/mako https://codeberg.org/dnkl/fnott descriptions. Dunst page doesn't specify it, but from my experience, it also starts with D-Bus activation.

Also, add fnott to examples.