### PR TITLE
Fix broken link in Useful Utilities page

### DIFF
--- a/pages/Useful Utilities/_index.md
+++ b/pages/Useful Utilities/_index.md
@@ -26,7 +26,7 @@ Hyprland working.
 
 - **[Clipboard Managers](./Clipboard-Managers)**
 
-- **[Hyprland Desktop Portal](./xdg-desktop-portal-hyprland)**
+- **[Hyprland Desktop Portal](../Hypr-Ecosystem/xdg-desktop-portal-hyprland)**
 
 - **[File Managers](./File-Managers)**
 


### PR DESCRIPTION
Fixed broken link to "Hyprland Desktop Portal" on the Useful Utilities page.