### PR TITLE
Add a note about manually restarting xdg-desktop-portal-hyprland.

### DIFF
--- a/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
+++ b/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
@@ -126,8 +126,6 @@ sleep 2
 /usr/lib/xdg-desktop-portal &
 ```
 
-
-
 Adjust the paths if they're incorrect.
 
 ***Note to systemd users:*** `xdg-desktop-portal-hyprland`  does not automatically restart when the Hyprland session is exited (`hyprctl dispatch exit`), then started again. To resolve this, add `exec-once = systemctl --user restart xdg-desktop-portal-hyprland.service` to your `hyprland.conf`:

--- a/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
+++ b/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
@@ -126,7 +126,11 @@ sleep 2
 /usr/lib/xdg-desktop-portal &
 ```
 
+
+
 Adjust the paths if they're incorrect.
+
+***Note to systemd users:*** `xdg-desktop-portal-hyprland`  does not automatically restart when the Hyprland session is exited (`hyprctl dispatch exit`), then started again. To resolve this, add `exec-once = systemctl --user restart xdg-desktop-portal-hyprland.service` to your `hyprland.conf`:
 
 ## Share picker doesn't use the system theme
 


### PR DESCRIPTION
XDPH doesn't automatically restart if Hyprland was exited with `hyprctl dispatch exit`, then started again. Added a note with a workaround for systemd users.