### PR TITLE
Fixed a broken link in Plugins/Development/Getting-Started

### DIFF
--- a/pages/Plugins/Development/Getting-Started.md
+++ b/pages/Plugins/Development/Getting-Started.md
@@ -145,7 +145,7 @@ your plugin in the nested session without worrying about nuking your actual
 session, and also being able to debug it easily.
 
 See more info in
-[the Contributing Section](../../Contributing-and-Debugging/#nesting-hyprland)
+[the Contributing Section](../../../Contributing-and-Debugging/#nesting-hyprland)
 
 ### More advanced stuff
 


### PR DESCRIPTION
There is a broken link in the following section:
https://wiki.hyprland.org/Plugins/Development/Getting-Started/#setting-up-a-development-environment.
I changed it from `../../` to `../../../` as per your recommendation.