### PR TITLE
update description for diff groupbar config values to better reflect their role as background colors and not borders.

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -356,10 +356,10 @@ _Subcategory `group:groupbar:`_
 | render_titles | whether to render titles in the group bar decoration | bool | true |
 | scrolling | whether scrolling in the groupbar changes group active window | bool | true |
 | text_color | controls the group bar text color | color | 0xffffffff |
-| col.active | active group border color | gradient | 0x66ffff00 |
-| col.inactive | inactive (out of focus) group border color | gradient | 0x66777700 |
-| col.locked_active | active locked group border color | gradient | 0x66ff5500 |
-| col.locked_inactive | inactive locked group border color | gradient | 0x66775500 |
+| col.active | active group bar background color | gradient | 0x66ffff00 |
+| col.inactive | inactive (out of focus) group bar background color | gradient | 0x66777700 |
+| col.locked_active | active locked group bar background color | gradient | 0x66ff5500 |
+| col.locked_inactive | inactive locked group bar background color | gradient | 0x66775500 |
 
 ### Misc
 


### PR DESCRIPTION
i stumbled on one of `The Linux Cast` video about [tabs in i3](https://youtu.be/sHWYr63mxpg). decided to check if hyprland has similar feature. went through the wiki and found it!

i noticed that the descriptions for the group bar config values were not entirely accurate cos these values actually modify the background color and not the border. so i thought, this was my chance to contribute to Hyprland!