### PR TITLE
fix(plugins): missing regex argument for nix search

### DIFF
--- a/pages/Nix/Plugins.md
+++ b/pages/Nix/Plugins.md
@@ -27,7 +27,7 @@ Nixpkgs. You can use them like this:
 ```
 
 You can find which plugins are included using
-`nix search nixpkgs#hyprlandPlugins`.
+`nix search nixpkgs#hyprlandPlugins ^`.
 
 ## hyprland-plugins
 


### PR DESCRIPTION
`nix search` needs at least one regex to match against: `nix search [option...] installable regex...`