### PR TITLE
fix edge case in smart gaps workspace-rule

### DIFF
--- a/pages/Configuring/Workspace-Rules.md
+++ b/pages/Configuring/Workspace-Rules.md
@@ -59,13 +59,10 @@ workspace = w[tg1-4], shadow:false
 To replicate "smart gaps" / "no gaps when only" from other WMs/Compositors, use this bad boy:
 
 ```ini
-workspace = w[t1], gapsout:0, gapsin:0
-workspace = w[tg1], gapsout:0, gapsin:0
+workspace = w[tv1], gapsout:0, gapsin:0
 workspace = f[1], gapsout:0, gapsin:0
-windowrulev2 = bordersize 0, floating:0, onworkspace:w[t1]
-windowrulev2 = rounding 0, floating:0, onworkspace:w[t1]
-windowrulev2 = bordersize 0, floating:0, onworkspace:w[tg1]
-windowrulev2 = rounding 0, floating:0, onworkspace:w[tg1]
+windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1]
+windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1]
 windowrulev2 = bordersize 0, floating:0, onworkspace:f[1]
 windowrulev2 = rounding 0, floating:0, onworkspace:f[1]
 ```


### PR DESCRIPTION
The previous example has an unhandled edge case: when you have exactly one tiled window and one tiled group, it still triggers the no-gaps rule, which I don't think anyone wants

pre-changes:

![image](https://github.com/user-attachments/assets/a7f6da3e-4694-417f-972a-a7d907732f26)

post-changes:

![image](https://github.com/user-attachments/assets/d06bdddd-5486-4c22-84f1-007dfb78309d)
