### PR TITLE
Changed all instances of activemon to focusedmon

### DIFF
--- a/pages/IPC/_index.md
+++ b/pages/IPC/_index.md
@@ -32,8 +32,8 @@ e.g.: `workspace>>2`
 
 | name | description | data |
 | --- | --- | --- |
-| workspace | emitted on workspace change. Is emitted ONLY when a user requests a workspace change, and is not emitted on mouse movements (see `activemon`) | `WORKSPACENAME` |
-| workspacev2 | emitted on workspace change. Is emitted ONLY when a user requests a workspace change, and is not emitted on mouse movements (see `activemon`) | `WORKSPACEID,WORKSPACENAME` |
+| workspace | emitted on workspace change. Is emitted ONLY when a user requests a workspace change, and is not emitted on mouse movements (see `focusedmon`) | `WORKSPACENAME` |
+| workspacev2 | emitted on workspace change. Is emitted ONLY when a user requests a workspace change, and is not emitted on mouse movements (see `focusedmon`) | `WORKSPACEID,WORKSPACENAME` |
 | focusedmon | emitted on the active monitor being changed. | `MONNAME,WORKSPACENAME` |
 | activewindow | emitted on the active window being changed. | `WINDOWCLASS,WINDOWTITLE` |
 | activewindowv2 | emitted on the active window being changed. | `WINDOWADDRESS` |


### PR DESCRIPTION
`activemon` appears to be an outdated term used for referring to `focusedmon`
All credits to SoSeDiK for finding this one:
https://discord.com/channels/961691461554950145/1070436481912549497/1305912205392216066