### PR TITLE
Variables: explain that rgb(a) supports hex and decimal values

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -31,9 +31,9 @@ the layout pages and not here. (See the Sidebar for Dwindle and Master layouts)
 
 You have 3 options:
 
-rgba(), e.g. `rgba(b3ff1aee)`
+rgba(), e.g. `rgba(b3ff1aee)`, or the decimal equivalent `rgba(179, 255, 26, 0.933)`
 
-rgb(), e.g. `rgb(b3ff1a)`
+rgb(), e.g. `rgb(b3ff1a)`, or the decimal equivalent  `rgb(179, 255, 26)`
 
 legacy, e.g. `0xeeb3ff1a` -> ARGB order
 


### PR DESCRIPTION
Ref.: https://github.com/hyprwm/Hyprland/pull/8476