### PR TITLE
Systemd-start: use `programs.hyprland.withUWSM` option for NixOS installation

### DIFF
--- a/pages/Useful Utilities/Systemd-start.md
+++ b/pages/Useful Utilities/Systemd-start.md
@@ -22,14 +22,7 @@ yay -S uwsm
 {{% details title="Nix/NixOS" closed="true" %}}
 
 ```nix
-programs.uwsm = {
-  enable = true;
-  waylandCompositors.hyprland = {
-    binPath = "/run/current-system/sw/bin/Hyprland";
-    comment = "Hyprland session managed by uwsm";
-    prettyName = "Hyprland";
-  };
-};
+programs.hyprland.withUWSM  = true;
 ```
 
 The above option generates a new desktop entry, `hyprland-uwsm.desktop`, which will be available in display managers.


### PR DESCRIPTION
Replaced the previous NixOS installation option with `programs.hyprland.withUWSM  = true;`.

The [resulting config](https://github.com/NixOS/nixpkgs/commit/04f223946ce67184dfe8d0a0c66b76f6fb91ab3c#diff-2a0030aad6c6a750df9d7404cc5f71bd41e6a3ff0183e5b80c5b79254637e0aaR100-R108) is identical to the previous option written in the wiki, but I'm unsure whether or not we should keep it on the page.




