### PR TITLE
Added a windowrulev2 to Screen-Sharing.md

### DIFF
--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -39,4 +39,5 @@ windowrulev2 = noanim, class:^(xwaylandvideobridge)$
 windowrulev2 = noinitialfocus, class:^(xwaylandvideobridge)$
 windowrulev2 = maxsize 1 1, class:^(xwaylandvideobridge)$
 windowrulev2 = noblur, class:^(xwaylandvideobridge)$
+windowrulev2 = nofocus, class:^(xwaylandvideobridge)$
 ```


### PR DESCRIPTION
This window rule is added to xwaylandvideobridge to prevent it being focused. This is a recommendation to users who use the mentioned package.