### PR TITLE
docs: fix missing heading due to misplaced codeblock

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -233,8 +233,6 @@ bindd = SUPER, Q, Open my favourite terminal, exec, kitty
 bindo = SUPER, XF86AudioNext, exec, playerctl next
 bind = SUPER, XF86AudioNext, exec, playerctl position +5
 ```
-# See Mouse Binds section for bindm usage
-```
 
 ## Mouse Binds
 


### PR DESCRIPTION
There was a code block that was wrapping one of the headings which had the effect where the heading would not show as a heading and also the next code block initiator was rendered in plain text.