### PR TITLE
preconfigured setups: remove end-4/dots-hyprland

### DIFF
--- a/pages/Getting Started/Preconfigured-setups.md
+++ b/pages/Getting Started/Preconfigured-setups.md
@@ -20,14 +20,6 @@ It includes simple gui settings apps, pre-configured feature-rich panels, a welc
 
 ![Image of ML4W dotfiles](https://i.ibb.co/6ydHNt9/screenshot-29-1.png)
 
-## end_4
-
-Like material styling? Want a lot of great apps? Don't mind a tiny bit of tinkering? end-4 has you covered.
-
-[GitHub](https://github.com/end-4/dots-hyprland)
-
-![Image of end-4's dotfiles](https://github.com/end-4/dots-hyprland/assets/97237370/5e081770-0f1e-45c4-ad9c-3d19f488cd85)
-
 ## prasanthrangan
 
 Prefer something more minimal, clean and aesthetic? Are you a terminal enjoyer?


### PR DESCRIPTION
As the author of end-4/dots-hyprland, I feel I cannot maintain it well for now and would like to have it removed from the wiki, at least temporarily, to not cause new users any issues.