### PR TITLE
hyprland-qtutils: add disable warning instructions

### DIFF
--- a/pages/Hypr Ecosystem/hyprland-qtutils.md
+++ b/pages/Hypr Ecosystem/hyprland-qtutils.md
@@ -4,3 +4,6 @@ title: hyprland-qtutils
 ---
 
 hyprland-qtutils is a small bunch of utility applications that hyprland might invoke. These are stuff like dialogs or popups.
+
+If not installed a warning on hyprland startup will be shown.<br/>
+You can disable it with `misc:disable_hyprland_qtutils_check` in the config file ([ref](../Configuring/Variables)).


### PR DESCRIPTION
Saw the warning and searched on google about that.
First result is this wiki page with no information about how to disable the warning... currently it is documented (see the reference), but not immediate to find, that's the reason of this PR.