### PR TITLE
Added glaze to packages needed for manual installation on Arch

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -389,7 +389,7 @@ C++ standard library has to support that (`gcc>=14` or `clang>=18`).
 {{% details title="Arch" closed="true" %}}
 
 ```plain
-yay -S ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang-git hyprcursor-git hyprwayland-scanner-git xcb-util-errors hyprutils-git hyprgraphics-git
+yay -S ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite libxrender pixman wayland-protocols cairo pango seatd libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang-git hyprcursor-git hyprwayland-scanner-git xcb-util-errors hyprutils-git glaze hyprgraphics-git
 ```
 
 _(Please make a pull request or open an issue if any packages are missing from


### PR DESCRIPTION
I was getting the following error when trying to build until I installed glaze from AUR:
```
CMake Error at hyprpm/CMakeLists.txt:13 (find_package):
  By not providing "Findglaze.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "glaze", but
  CMake did not find one.

  Could not find a package configuration file provided by "glaze" with any of
  the following names:

    glazeConfig.cmake
    glaze-config.cmake

  Add the installation prefix of "glaze" to CMAKE_PREFIX_PATH or set
  "glaze_DIR" to a directory containing one of the above files.  If "glaze"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
make[1]: *** [Makefile:15: release] Error 1
make[1]: Leaving directory '/home/nnra/Packages/Hyprland'
make: *** [Makefile:32: all] Error 2
```

NOTE: Packages for other distros might have to get updated too, I don't have the ability to test them out so I didn't wanna change anything yet.