### PR TITLE
Document that hyprlock config is required.

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -8,8 +8,7 @@ for Hyprland.
 
 ## Configuration
 
-Configuration is done via the config file at `~/.config/hypr/hyprlock.conf`. It
-is not required, but recommended. Without it, locking shows the current screen.
+Configuration is done via the config file at `~/.config/hypr/hyprlock.conf`. This file must exist to run `hyprlock`.
 
 ### Variable types
 


### PR DESCRIPTION
Without a config, hyprlock fails with:

```
[CRITICAL] ConfigManager threw: Could not find config in HOME, XDG_CONFIG_HOME, XDG_CONFIG_DIRS or /etc/hypr.
```

This was mentioned in https://github.com/hyprwm/hyprlock/issues/450 and closed with

>  hyprlock with no config is more confusing than anything, as it will not render anything

So I'm assuming this is behaving as expected and the docs just need to be fixed.
