### PR TITLE
Document `decoration:rounding_power` and window rule `roundingpower`

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -108,6 +108,7 @@ Doing `general:snap {` is **invalid**!
 | name | description | type | default |
 | --- | --- | --- | --- |
 | rounding | rounded corners' radius (in layout px) | int | 0 |
+| rounding_power | adjusts the curve used for rounding corners, larger is smoother, 2.0 is a circle, 4.0 is a squircle. [2.0 - 10.0] | float | 2.0 |
 | active_opacity | opacity of active windows. [0.0 - 1.0] | float | 1.0 |
 | inactive_opacity | opacity of inactive windows. [0.0 - 1.0] | float | 1.0 |
 | fullscreen_opacity | opacity of fullscreen windows. [0.0 - 1.0] | float | 1.0 |

--- a/pages/Configuring/Window-Rules.md
+++ b/pages/Configuring/Window-Rules.md
@@ -159,6 +159,7 @@ The following rules can also be set with [`setprop`](../Dispatchers#setprop):
 | ---- | ----------- |
 | bordersize \[int\] | sets the border size |
 | rounding \[int\] | forces the application to have X pixels of rounding, ignoring the set default (in `decoration:rounding`). Has to be an int. |
+| roundingpower \[float\] | overrides the rounding power for the window (see `decoration:rounding_power`). |
 | allowsinput \[on\] | forces an XWayland window to receive input, even if it requests not to do so. (Might fix issues like e.g. Game Launchers not receiving focus for some reason) |
 | dimaround \[on\] | dims everything around the window . Please note this rule is meant for floating windows and using it on tiled ones may result in strange behavior. |
 | decorate \[on\] | whether to draw window decorations or not |


### PR DESCRIPTION
Document features added in Hyprland PR [#8943](https://github.com/hyprwm/Hyprland/pull/8943).