### PR TITLE
Getting Started:Master-Tutotial - Improve clarity of FAQ links in cursor setup documentation

### DIFF
--- a/pages/Getting Started/Master-Tutorial.md
+++ b/pages/Getting Started/Master-Tutorial.md
@@ -123,10 +123,10 @@ about configuring Hyprland to your liking.
 ## Cursors
 
 Cursors are a notorious pain to set up when you don't know how. See
-[this FAQ entry](../../FAQ#how-do-i-change-me-mouse-cursor)
+[this FAQ entry on changing your mouse cursor](../../FAQ#how-do-i-change-me-mouse-cursor)
 
 If your cursor does not appear, see
-[this FAQ entry](../../FAQ#me-cursor-no-render)
+[this FAQ entry on cursor not rendering](../../FAQ#me-cursor-no-render)
 
 ## Themes
 


### PR DESCRIPTION
It's not very clear that the two links lead to different locations. This change makes it more obvious.