### PR TITLE
fix: hyperlink to 404 page had an extra .md at the file name

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -182,7 +182,7 @@ for example,
 bindd = SUPER, Q, Open my favourite terminal, exec, kitty
 ```
 
-If you want to access your description you can use `hyprctl binds`. For more information have a look at [Using Hyprctl](../Using-hyprctl.md).
+If you want to access your description you can use `hyprctl binds`. For more information have a look at [Using Hyprctl](../Using-hyprctl).
 
 ## Bind flags
 


### PR DESCRIPTION
In https://wiki.hyprland.org/Configuring/Binds/, the hyperlink on the sentence
- "If you want to access your description you can use `hyprctl binds`. For more information have a look at **Using Hyprctl**" 

is as pointing to a non-existent location. That is because it points to https://wiki.hyprland.org/Configuring/Using-hyprctl.md when it should point to https://wiki.hyprland.org/Configuring/Using-hyprctl  (no .md at the end).