### PR TITLE
Fix typo in Hyprland on Home Manager.md

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -69,7 +69,7 @@ Don't forget to replace `user@hostname` with your username and hostname!
             enable = true;
             # set the flake package
             package = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
-            portalPackage = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portla-hyprland;
+            portalPackage = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland;
           };
         }
         # ...
@@ -107,7 +107,7 @@ in {
     enable = true;
     # set the flake package
     package = hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
-    portalPackage = hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portla-hyprland;
+    portalPackage = hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland;
   }
 }
 ```


### PR DESCRIPTION
Since this code is meant to be copied, this typo is particularly annoying.