### PR TITLE
home-manager: clarify setting HM package to `null` on NixOS

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -203,6 +203,27 @@ Example configuration:
 }
 ```
 
+### Using the Home-Manager module with NixOS
+
+If you want to use the Home Manager module while using the Hyprland package you've
+defined in your NixOS module, you can now do so as long as you're running
+[Home Manager `5dc1c2e40410f7dabef3ba8bf4fdb3145eae3ceb`](https://github.com/nix-community/home-manager/commit/5dc1c2e40410f7dabef3ba8bf4fdb3145eae3ceb)
+or later by setting your `package` and `portalPackage` to `null`.
+
+```nix {filename="home.nix"}
+wayland.windowManager.hyprland = {
+  enable = true;
+  # set the Hyprland and XDPH packages to null to use the ones from the NixOS module
+  package = null;
+  portalPackage = null;
+};
+```
+
+Make sure not to mix versions of Hyprland and XDPH. If in your NixOS module you've
+set your Hyprland package to be from the flake, you should do the same for your
+XDPH package as well. The same goes for if you set the Home Manager Hyprland
+module package to `null`, you should also set the XDPH package to `null`.
+
 ### Programs don't work in systemd services, but do on the terminal
 
 This problem is related to systemd not importing the environment by default. It

--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -219,10 +219,9 @@ wayland.windowManager.hyprland = {
 };
 ```
 
-Make sure not to mix versions of Hyprland and XDPH. If in your NixOS module you've
-set your Hyprland package to be from the flake, you should do the same for your
-XDPH package as well. The same goes for if you set the Home Manager Hyprland
-module package to `null`, you should also set the XDPH package to `null`.
+Make sure **not** to mix versions of Hyprland and XDPH.
+If your NixOS config uses Hyprland from the flake, you should also use XDPH from the flake.
+If you set the Home Manager Hyprland module package to `null`, you should also set the XDPH package to `null`.
 
 ### Programs don't work in systemd services, but do on the terminal
 


### PR DESCRIPTION
Following the introduction of `xdg.portal` settings in Home Manager, it's now possible to set `wayland.windowManager.hyprland.package` to `null`.

One issue I (as well as a couple of others in the Hyprland Discord) encountered, was not realising that without manually setting `wayland.windowManager.hyprland.portalPackage = null` in our configs as well, we'd encounter a broken XDPH caused by using the Hyprland Flake for both Hyprland and XDPH in our NixOS configurations, and then overwriting our XDPH with `nixpkgs` upstream of XDPH in Home Manager.

This adds a section on how to set the Home Manager `package` and `portalPackage` to `null` without causing any issues relating to mixing versions of Hyprland and XDPH.