### PR TITLE
Hypr Ecosystem/hyprpaper: rewrite `reload` docs

### DIFF
--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -118,9 +118,40 @@ wallpaper = monitor, contain:/home/me/amongus.png
 You can use `unload` to unload preloaded images. You can also specify `unload all`
 to unload all images or `unload unused` to unload images that aren't being used.
 
-Also you can use `reload` to unload preloaded image from your monitor(s),
-preload another and set it to your monitor(s). It has the same syntax as
-`wallpaper` keyword.
+### The `reload` keyword
+
+The `reload` keyword allows you to set / change wallpapers without
+having to preload them. For example, you could have a completely empty
+hyprpaper config (with [IPC](#IPC) enabled!!), and run the below command to
+very simply set your wallpaper (this example sets the wallpaper for
+all monitors):
+```
+hyprctl hyprpaper reload ,"~/amogus.png"
+```
+
+Running this command again with a new wallpaper would effectively swap
+the wallpaper with the new one, automating the whole preload, set,
+unload old sequence.
+
+#### Using this keyword to randomize your wallpaper
+
+You can also use this simple `reload` functionality to randomize your wallpaper. Using a simple script like so would do it very easily:
+
+```bash
+#!/usr/bin/env bash
+
+WALLPAPER_DIR="$HOME/wallpapers/"
+CURRENT_WALL=$(hyprctl hyprpaper listloaded)
+
+# Get a random wallpaper that is not the current one
+WALLPAPER=$(find "$WALLPAPER_DIR" -type f ! -name "$(basename "$CURRENT_WALL")" | shuf -n 1)
+
+# Apply the selected wallpaper
+hyprctl hyprpaper reload ,"$WALLPAPER"
+```
+
+Make sure to change the `WALLPAPER_DIR` to your own wallpaper directory. You can then run this
+script in your Hyprland config with a keybind.
 
 ### Run at startup
 


### PR DESCRIPTION
This PR rewrites and extends the `reload` keyword hyprpaper documentation.

This section was originally very short, with no example provided and only a very short description, this led to a lot of people missing this option and instead going with the old "unload, preload, set" combo which isn't needed and probably causes issues with the transition.

Examples of people missing this config option is seen in the discord server and hyprpaper issue tracker:

https://canary.discord.com/channels/961691461554950145/1215490894804029450/1335447955339087882

And I also missed it too when i first started using hyprpaper.

I also added a small piece of documentation about how to randomize your wallpaper using the `reload` keyword. This is in response to https://github.com/hyprwm/hyprpaper/issues/194 where people (including vaxry lmfao) mentioned sed'ing the config and relaunching hyprpaper as a good solution to it. The simple script I wrote is instead much better with no reloading of hyprland being needed. Simply change the wallpaper directory to wherever your ones are stored. (It also checks to make sure it doesn't set the same wallpaper as what is currently applied!)

Let me know if you need any changes or if I should make the script more in depth, i.e. check for only .png, .jpg, .jpeg, or whatever. imo it's fine as it is but I could use another persons opinion.