### PR TITLE
nvidia: update DRM kernel mode setting section

### DIFF
--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -54,8 +54,10 @@ Install the following packages:
 
 ## DRM kernel mode setting
 
-If you are on driver version 560.35.03-5 or ealier NVIDIA does not load kernel mode setting by default,
-enabling it is required to make Wayland compositors function properly.
+On driver version 560.35.03-5 or earlier NVIDIA does not load kernel mode
+setting by default. Enabling it is required to make Wayland compositors
+function properly.
+
 To enable it, the NVIDIA driver modules need to be added to the initramfs.
 
 Edit `/etc/mkinitcpio.conf`. In the `MODULES` array, add the following module names:

--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -72,6 +72,8 @@ options nvidia_drm modeset=1 fbdev=1
 
 Lastly, rebuild the initramfs with `sudo mkinitcpio -P`, and reboot.
 
+To verify that DRM is actually enabled, run `cat /sys/module/nvidia_drm/parameters/modeset` which should return `Y`.
+
 More information is available [here](https://wiki.archlinux.org/title/NVIDIA#DRM_kernel_mode_setting).
 
 ## Environment variables

--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -54,9 +54,9 @@ Install the following packages:
 
 ## DRM kernel mode setting
 
-Since NVIDIA does not load kernel mode setting by default, enabling it is
-required to make Wayland compositors function properly. To enable it, the NVIDIA
-driver modules need to be added to the initramfs.
+If you are on driver version 560.35.03-5 or ealier NVIDIA does not load kernel mode setting by default,
+enabling it is required to make Wayland compositors function properly.
+To enable it, the NVIDIA driver modules need to be added to the initramfs.
 
 Edit `/etc/mkinitcpio.conf`. In the `MODULES` array, add the following module names:
 


### PR DESCRIPTION
Clarifies that DRM kernel mode setting now enabled by default on drivers newer than version 560.35.03-5 and adds a small command to check if its already enabled.

[Source](https://wiki.archlinux.org/title/NVIDIA#DRM_kernel_mode_setting)

ref #968 