### PR TITLE
Installation: add missing dependency for Arch

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -377,7 +377,7 @@ C++ standard library has to support that (`gcc>=14` or `clang>=18`).
 {{% details title="Arch" closed="true" %}}
 
 ```plain
-yay -S ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite libxrender pixman wayland-protocols cairo pango libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang-git hyprcursor-git hyprwayland-scanner-git xcb-util-errors hyprutils-git glaze hyprgraphics-git
+yay -S ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite libxrender libxcursor pixman wayland-protocols cairo pango libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang-git hyprcursor-git hyprwayland-scanner-git xcb-util-errors hyprutils-git glaze hyprgraphics-git
 ```
 
 _(Please make a pull request or open an issue if any packages are missing from


### PR DESCRIPTION
Added ```libxcursor``` dependency to <em>Manual Installation - Arch<em>