### PR TITLE
Hypr-Ecosystem/hyprsunset: add 'run at startup' section

### DIFF
--- a/pages/Hypr Ecosystem/hyprsunset.md
+++ b/pages/Hypr Ecosystem/hyprsunset.md
@@ -27,6 +27,10 @@ below the monitor's minimum.
 
 See `hyprsunset --help`.
 
+## Run at startup
+
+To autostart hyprsunset, add: `exec-once = hyprsunset` to your `hyprland.conf` . If you start Hyprland with [uwsm](../../Useful-Utilities/Systemd-start), you can also use `systemctl --user enable --now hyprsunset.service` command.
+
 ## IPC
 
 `hyprsunset` supports IPC via hyprctl. Both color temperature and the gamma filter are adjustable:

--- a/pages/Hypr Ecosystem/hyprsunset.md
+++ b/pages/Hypr Ecosystem/hyprsunset.md
@@ -29,7 +29,8 @@ See `hyprsunset --help`.
 
 ## Run at startup
 
-To autostart hyprsunset, add: `exec-once = hyprsunset` to your `hyprland.conf` . If you start Hyprland with [uwsm](../../Useful-Utilities/Systemd-start), you can also use `systemctl --user enable --now hyprsunset.service` command.
+To autostart hyprsunset, add: `exec-once = hyprsunset` to your `hyprland.conf`.
+Alternatively, use `systemctl --user enable --now hyprsunset.service` in order to use hyprsunset as a systemd user service.
 
 ## IPC
 


### PR DESCRIPTION
Since hyprsunset now can be controlled via IPC, it makes sense to autostart it with the rest of the session. 

Also, https://github.com/hyprwm/hyprsunset/pull/19