### PR TITLE
Useful Utilities/Status Bars: remove unclear waybar config instruction

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -10,7 +10,7 @@ supports Hyprland by default. To use it, it's recommended to use your distro's
 package.
 
 To start configuring, copy the configuration files from
-`/etc/xdg/waybar/` into `~/.config/waybar/`. Then, in `~/.config/waybar/config`
+`/etc/xdg/waybar/` into `~/.config/waybar/`.
 
 To use the workspaces module, replace all the occurrences of `sway/workspaces`
 with `hyprland/workspaces`. Addionally replace all occurences of `sway/mode` with `hyprland/submap`


### PR DESCRIPTION
Used to make sense with 
```
Then, in `~/.config/waybar/config` replace all the references to `sway/workspaces` with `hyprland/workspaces`.
```

but now since the instruction for that is written below, it leaves an unnecessary instruction.

edit: added commentary to pr