### PR TITLE
Hypr Ecosystem/hyprlock.md: Point to pambase and faillock

### DIFF
--- a/pages/Hypr Ecosystem/hyprlock.md
+++ b/pages/Hypr Ecosystem/hyprlock.md
@@ -94,6 +94,10 @@ global
     ↳ inputFieldDots - fade in/out for individual dots in the input field
 ```
 
+### System Configuration
+
+On Arch Linux, by default, hyprlock integrates with [pambase](https://archlinux.org/packages/?name=pambase) through `pam_faillock.so`, which forces a 10 minute timeout after 3 failed unlocks. If you would like to change this, refer to the [arch linux wiki](https://wiki.archlinux.org/title/Security#Lock_out_user_after_three_failed_login_attempts) and update the file `/etc/security/faillock.conf` file with parameters `unlock_time`, `fail_interval`, and `deny` as needed.
+
 ## Keyboard Shortcuts and Actions
 
 The following keys and key-combinations describe hyprlock's default behaviour:


### PR DESCRIPTION
Hi team,

First PR here. Let me know if you need some CLA/MSA/NDA etc.

## Details:
- Add System Configuration section pointing users to pambase and faillock to tweak retry/lockout params.

## Why this is needed:
Like every good Arch user, I own a cat. He loves to walk on my keyboard. When that happens I get locked out. I initially wanted to patch hyprlock with some config options, but found out there's already a knob for all of this. Sharing to spare others pain.

Source: https://wiki.archlinux.org/title/Security#Lock_out_user_after_three_failed_login_attempts