### PR TITLE
XWayland: add the abstract Unix socket description and new variable information

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -438,6 +438,7 @@ _Subcategory `group:groupbar:`_
 | enabled | allow running applications using X11 | bool | true |
 | use_nearest_neighbor | uses the nearest neighbor filtering for xwayland apps, making them pixelated rather than blurry | bool | true |
 | force_zero_scaling | forces a scale of 1 on xwayland windows on scaled displays. | bool | false |
+| create_abstract_socket | Create the [abstract Unix domain socket](../XWayland/#abstract-unix-domain-socket) for XWayland connections. (XWayland restart is required for changes to take effect; Linux only) | bool | false |
 
 ### OpenGL
 

--- a/pages/Configuring/XWayland.md
+++ b/pages/Configuring/XWayland.md
@@ -39,3 +39,19 @@ The GDK_SCALE variable won't conflict with Wayland-native GTK programs.
 XWayland HiDPI patches are no longer supported. Do not use them.
 
 {{</ callout >}}
+
+## Abstract Unix domain socket
+
+X11 applications use Unix domain sockets to communicate with XWayland. On Linux, libX11 prefers
+to use the abstract Unix domain socket. This type of socket uses a separate, abstract namespace that
+is independent of the host filesystem. This makes abstract sockets more flexible
+but harder to [isolate](https://github.com/hyprwm/Hyprland/pull/8874)
+for some kinds of sandboxes like Flatpak. However, removing the abstract socket
+has [potential](https://gitlab.gnome.org/GNOME/mutter/-/issues/1613) security
+and compatibility issues.
+
+Keeping that in mind, we add the [`xwayland:create_abstract_socket`](../Variables/#xwayland) option.
+When the abstract socket is disabled, only the regular Unix domain
+socket will be created.
+
+_\* Abstract Unix domain sockets are available only on Linux-based systems_


### PR DESCRIPTION
In follow to hyprwm/Hyprland#9615
* add information about `xwayland:create_abstract_socket`
* add brief description of the abstract unix socket issue