### PR TITLE
Changing "debs" to "devs"

### DIFF
--- a/pages/Contributing and Debugging/_index.md
+++ b/pages/Contributing and Debugging/_index.md
@@ -14,7 +14,7 @@ For issues, please see
 
 ### Required packages
 
-See [manual build](https://wiki.hyprland.org/Getting-Started/Installation/#manual-manual-build) for deps.
+See [manual build](https://wiki.hyprland.org/Getting-Started/Installation/#manual-manual-build) for devs.
 
 ### Recommended, CMake
 


### PR DESCRIPTION
Changing "debs" to "devs" in "Contibuting and Debugging" since i deem "debs" to be nonsensical in this context