### PR TITLE
Groupbar: add text_offset and keep_upper_gap settings

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -363,6 +363,7 @@ _Subcategory `group:groupbar:`_
 | stacked | render the groupbar as a vertical stack | bool | false |
 | priority | sets the decoration priority for groupbars | int | 3 |
 | render_titles | whether to render titles in the group bar decoration | bool | true |
+| text_offset | adjust vertical position for titles | int | 0 |
 | scrolling | whether scrolling in the groupbar changes group active window | bool | true |
 | rounding | how much to round the indicator | int | 1 |
 | gradient_rounding | how much to round the gradients | int | 2 |
@@ -375,6 +376,7 @@ _Subcategory `group:groupbar:`_
 | col.locked_inactive | inactive locked group bar background color | gradient | 0x66775500 |
 | gaps_in | gap size between gradients | int | 2 |
 | gaps_out | gap size between gradients and window | int | 2 |
+| keep_upper_gap | add or remove upper gap | bool | true |
 
 ### Misc
 


### PR DESCRIPTION
Adds two new groupbar settings:

    group:groupbar:keep_upper_gap - allows to keep or remove upper outer gap
    group:groupbar:text_offset - allows to adjust vertical alignment for text in a group bar

All settings are defaulted to values that keep current layout AS IS.

Demo video:
https://github.com/user-attachments/assets/dbae0131-a786-4861-94c8-7a6e55d7a65d

PR with implementation:
https://github.com/hyprwm/Hyprland/pull/9733