### PR TITLE
Update iconTheme example

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -191,7 +191,7 @@ Example configuration:
     };
 
     iconTheme = {
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
       name = "Adwaita";
     };
 


### PR DESCRIPTION
The package gnome.adwaita-icon-theme was moved to a top-level package.