### PR TITLE
Draft, Discussion, RFC: New Issue Guidelines for Hyprland.

### DIFF
--- a/pages/Contributing and Debugging/Issue-Guidelines.md
+++ b/pages/Contributing and Debugging/Issue-Guidelines.md
@@ -1,0 +1,59 @@
+---
+title: Issue Guidelines
+---
+
+Due to the influx of low quality or incomprehensible issues,
+we prefer to begin possible bug reports or feature requests as *discussions*,
+and elevate them to issues if they can be confirmed by a member to be relevant,
+and once enough information about the problem has been gathered.
+
+{{< callout type=info >}}
+
+### Why?
+
+We are volunteers, doing this in our free time. Out of respect, please read this document
+_fully_ before posting an issue _or_ discussion. If you can spend a few minutes reading this,
+it saves us, the developers, much more time overall, so we can deliver fixes and features faster.
+
+Thank you!
+
+{{< /callout >}}
+
+## Issue Guidelines
+
+If you are experiencing a bug, or missing a feature, please do not open an issue.
+Instead, we ask you to open a [discussion](https://github.com/hyprwm/Hyprland/discussions).
+
+### Before you start a discussion
+
+_Search the discussions and issues thoroughly_. It's likely that there's already one open for your bug / feature that you can
+just "like" instead of wasting both your time writing a new one and our time closing it and redirecting you.
+
+### The lifecycle of a discussion
+
+A discussion is opened by a user.
+
+For bugs:
+- If a discussion is solved, user error, or not a hyprland issue, it gets closed.
+- If a discussion is a Hyprland problem, but cannot be tied to Hyprland in a clear way, or is not reproducible, it stays a discussion until that changes.
+- If a discussion is reproducible, a member of Hyprland promotes the discussion to an issue by opening an issue with the key information and links the original discussion.
+
+For feature requests:
+- If a discussion describes a feature that is already possible (via scripts, features, or official tools), invalid, or not applicable, it gets closed.
+- If a discussion describes a feature that is _not_ already possible, it stays a discussion.
+- If a discussion describes a feature that is _not_ already possible, and it gathers enough attention, a member may promote it to an issue by opening an issue with the key information and links the original discussion.
+
+Please note we are all volunteers and our numbers are small, so issues may stay idle.
+
+### Gathering attention for your discussion / a discussion you care about
+
+Avoid posting comments such as "when fix?". Instead, use the thumbs up
+reaction under the discussion, or issue (if one exists).
+
+If a discussion has reached 5 "likes" or more, and it hasn't been promoted, you may ping a member in the discussion
+(`@vaxerski`, `@fufexan` or `@notashelf` are the most likely ones to work)
+
+Please ***do not*** ping the members just because the discussion has become stale,
+or failed to gather attention. If that is the case, attempt to bring it back
+on track by posting *further* relevant information that might spark a discussion,
+or tell people interested about the discussion so that they can "like" it.


### PR DESCRIPTION
This is a draft for the new issue guidelines. They are inspired by Ghostty's approach.

Our issues are unmaintainable on Hyprland. Let's fix this.

Comments welcome, reviews welcome.

TL;DR: We are banning opening issues, and instead, people open discussions. Members can "promote" discussions to issues.

All existing issues under Hyprland would be closed with this coming into effect.

BEFORE EFFECTIVE CHECKLIST:
- [x] Discussion period (a few days)
- [x] Restructuring of discussions (rethinking categories and labels)
- [x] Remove issue templates and replace with a "DONT OPEN ISSUE" one.

AFTER EFFECTIVE CHECKLIST:
- [ ] Close all Hyprland issues with a comment referencing these changes