### PR TITLE
animations: document anim style for windowsIn and windowsOut

### DIFF
--- a/pages/Configuring/Animations.md
+++ b/pages/Configuring/Animations.md
@@ -36,8 +36,8 @@ animation = fade, 0
 ```txt
 global
   ↳ windows - styles: slide, popin, gnomed
-    ↳ windowsIn - window open
-    ↳ windowsOut - window close
+    ↳ windowsIn - window open - styles: same as windows
+    ↳ windowsOut - window close - styles: same as windows
     ↳ windowsMove - everything in between, moving, dragging, resizing.
   ↳ layers - styles: slide, popin, fade
     ↳ layersIn - layer open


### PR DESCRIPTION
I just learnt that windows can have different animations for `windowsIn` and `windowsOut` in this discussion https://github.com/hyprwm/Hyprland/issues/9894#issuecomment-2804920126

AFAIK this feature was not documented, this PR simply describes this feature in the anim tree docs