### PR TITLE
Update multi-gpu lspci instructions to include all display controllers

### DIFF
--- a/pages/Configuring/Multi-GPU.md
+++ b/pages/Configuring/Multi-GPU.md
@@ -16,7 +16,7 @@ This setup is very common in the likes of gaming laptops, GPU-passthrough
 
 For this case, the writer is taking the example of their laptop.
 
-Upon running `lspci | grep -E 'VGA|3D'`, One can list all the video devices
+Upon running `lspci -d ::03xx'`, one can list all the PCI display controllers
 available.
 
 ```plain


### PR DESCRIPTION
The current command with `grep VGA|3D` doesn't show my integrated intel graphics. `::03xx` is all PCI devices of class 'display controller'

```console
> lspci -d ::03xx
00:02.0 Display controller: Intel Corporation AlderLake-S GT1 (rev 0c)
01:00.0 VGA compatible controller: NVIDIA Corporation GA102 [GeForce RTX 3080 Ti] (rev a1)
```