### PR TITLE
FAQ/_index.md: Update xdph script

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -254,9 +254,9 @@ In such cases, a script like this:
 ```bash
 #!/usr/bin/env bash
 sleep 4
-killall -e xdg-desktop-portal-wlr
+killall -e xdg-desktop-portal-hyprland
 killall xdg-desktop-portal
-/usr/lib/xdg-desktop-portal-wlr &
+/usr/lib/xdg-desktop-portal-hyprland &
 sleep 4
 /usr/lib/xdg-desktop-portal &
 ```


### PR DESCRIPTION
Screen sharing section already asked user to install `xdg-desktop-portal-hyprland`. But FAQ section's config is still the 3-year-ago version. 

For users new to Hyprland might feel confused about the inconsistent name.

![image](https://github.com/user-attachments/assets/e1432533-cc67-4e26-ab16-a8dc5ecb034b)

![image](https://github.com/user-attachments/assets/f4b5306d-fee7-4541-aff3-198a82c14f63)

![image](https://github.com/user-attachments/assets/c369e455-bddd-471f-a501-ae48ca07769d)

