### PR TITLE
Variables and Binds: correct input:drag_threshold to binds:drag_threshold

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -203,8 +203,8 @@ Flags:
 ```plain
 l -> locked, will also work when an input inhibitor (e.g. a lockscreen) is active.
 r -> release, will trigger on release of a key.
-c -> click, will trigger on release of a key or button as long as the mouse cursor stays inside input:drag_threshold.
-g -> drag, will trigger on release of a key or button as long as the mouse cursor moves outside input:drag_threshold.
+c -> click, will trigger on release of a key or button as long as the mouse cursor stays inside binds:drag_threshold.
+g -> drag, will trigger on release of a key or button as long as the mouse cursor moves outside binds:drag_threshold.
 o -> longPress, will trigger on long press of a key.
 e -> repeat, will repeat when held.
 n -> non-consuming, key/mouse events will be passed to the active window in addition to triggering the dispatcher.
@@ -239,10 +239,10 @@ bind = SUPER, XF86AudioNext, exec, playerctl position +5
 ## Mouse Binds
 
 Mouse binds are binds that rely on mouse movement. They will have one less arg.
-`input:drag_threshold` can be used to differentiate between clicks and drags with the same button:
+`binds:drag_threshold` can be used to differentiate between clicks and drags with the same button:
 
 ```ini
-input {
+binds {
     drag_threshold = 10
 }
 bindm = ALT, mouse:272, movewindow

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -214,7 +214,6 @@ _[More about Animations](../Animations)._
 | special_fallthrough | if enabled, having only floating windows in the special workspace will not block focusing windows in the regular workspace. | bool | false |
 | off_window_axis_events | Handles axis events around (gaps/border for tiled, dragarea/border for floated) a focused window. `0` ignores axis events `1` sends out-of-bound coordinates `2` fakes pointer coordinates to the closest point inside the window `3` warps the cursor to the closest point inside the window | int | 1 |
 | emulate_discrete_scroll | Emulates discrete scrolling from high resolution scrolling events. `0` disables it, `1` enables handling of non-standard events only, and `2` force enables all scroll wheel events to be handled | int | 1 |
-| drag_threshold | Movement threshold in pixels for window dragging and c/g bind flags. 0 to disable and grab on mousedown. | int | 0 |
 
 {{< callout type=info >}}
 
@@ -440,6 +439,7 @@ _Subcategory `group:groupbar:`_
 | disable_keybind_grabbing | If enabled, apps that request keybinds to be disabled (e.g. VMs) will not be able to do so. | bool | false |
 | window_direction_monitor_fallback | If enabled, moving a window or focus over the edge of a monitor with a direction will move it to the next monitor in that direction. | bool | true |
 | allow_pin_fullscreen | If enabled, Allow fullscreen to pinned windows, and restore their pinned status afterwards | bool | false |
+| drag_threshold | Movement threshold in pixels for window dragging and c/g bind flags. 0 to disable and grab on mousedown. | int | 0 |
 
 ### XWayland
 


### PR DESCRIPTION
I moved parts mentioning `input:drag_threshold` to now mention `binds:drag_threshold` because `input:drag_threshold` doesn't exist. Also corrected the example config given in Binds.md

See [Hyprland Discussion #10180](https://github.com/hyprwm/Hyprland/discussions/10180)