### PR TITLE
Added instructions to mitigate VRR's brightness flickering

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -137,6 +137,10 @@ rate, and rapidly changing refresh rates (for example, when the screen
 momentarily updates after pressing a key) will cause rapid changes in
 brightness.
 
+If you want VRR always enabled regardless,
+the flickering can be mitigated or even removed by changing the VRR range in your monitor's EDID.
+More information in [the ArchWiki](https://wiki.archlinux.org/title/Kernel_mode_setting#Forcing_modes_and_EDID).
+
 ### How do I update?
 
 Open a terminal where you cloned the repo.


### PR DESCRIPTION
Hello,
VRR's flickering can somewhat be mitigated by widening or reducing the VRR range.
Having VRR enabled all the time can help desktop smoothness for some reason I don't understand, making this trick useful in some cases.
For instance, I fixed my year-old flickering by changing my monitor's VRR range from [48, 144] to [60, 144] in my EDID.
It looks like getting too low on refresh rate can trigger funny behaviours on poorly-designed monitors, so highering the lower boundary of VRR range can prevent this behaviour.
On the contrary, I saw somewhere that widening this range can lower the limit refresh rate triggering this issue, no clue why though.
I really wanted to have VRR enabled all time because it makes my desktop way smoother, whatever mininum GPU frequency, CPU governor or hyprland options I could set and hope it will help someone in the wiki.