### PR TITLE
Nix/Hyprland on NixOS: Change hardware.opengl to hardware.graphics

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -100,7 +100,7 @@ You can fix this issue by using `mesa` from Hyprland's `nixpkgs` input:
 {pkgs, inputs, ...}: let
   pkgs-unstable = inputs.hyprland.inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system};
 in {
-  hardware.opengl = {
+  hardware.graphics = {
     package = pkgs-unstable.mesa.drivers;
 
     # if you also want 32-bit support (e.g for Steam)


### PR DESCRIPTION
hardware.opengl has been deprecated in nixpkgs since 24.11