### PR TITLE
Configuring/Window-Rules: Add fullscreenclients callout

### DIFF
--- a/pages/Configuring/Window-Rules.md
+++ b/pages/Configuring/Window-Rules.md
@@ -82,6 +82,15 @@ size, you can use `hyprctl clients`.
 
 {{< /callout >}}
 
+
+{{< callout type=info >}}
+
+In the output of the `hyprctl clients` command:
+`fullscreen` refers to `fullscreenstate.internal` and
+`fullscreenClient` refers to `fullscreenstate.client`
+
+{{< /callout >}}
+
 ### RegEx writing
 
 Please note Hyprland uses Google's RE2 for parsing Regex. This means that all operations requiring polynomial


### PR DESCRIPTION
Added callout notifying users of the relation between the fullscreen outputs of the `hyprctl clients` command and the fullscreen configs in window rules

See https://github.com/hyprwm/Hyprland/pull/10190 for more info