### PR TITLE
Nix/Cachix: improve substituters documentation

### DIFF
--- a/pages/Nix/Cachix.md
+++ b/pages/Nix/Cachix.md
@@ -26,6 +26,7 @@ using the Hyprland flake package.
 {
   nix.settings = {
     substituters = ["https://hyprland.cachix.org"];
+    trusted-substituters = ["https://hyprland.cachix.org"];
     trusted-public-keys = ["hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="];
   };
 }


### PR DESCRIPTION
For a substituter to be used, [one of the following has to be met](https://nix.dev/manual/nix/2.24/command-ref/conf-file.html#conf-substituters):

- the substituter is under the trusted-substituters list
- The user calling Nix is in the trusted-users list


I think it is better to recommend adding hyprland.cachix.org as a trusted substituter, rather than adding to the trusted-users list, but at least one of these needs to be done for the substituter to be used.