### PR TITLE
Nix/Hyprland on NixOS: update deprecated definitions

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -101,11 +101,11 @@ You can fix this issue by using `mesa` from Hyprland's `nixpkgs` input:
   pkgs-unstable = inputs.hyprland.inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system};
 in {
   hardware.graphics = {
-    package = pkgs-unstable.mesa.drivers;
+    package = pkgs-unstable.mesa;
 
     # if you also want 32-bit support (e.g for Steam)
-    driSupport32Bit = true;
-    package32 = pkgs-unstable.pkgsi686Linux.mesa.drivers;
+    enable32Bit = true;
+    package32 = pkgs-unstable.pkgsi686Linux.mesa;
   };
 }
 ```


### PR DESCRIPTION
updates wiki to use new definitions that were deprecated in nix

from Nix:
```
evaluation warning: `mesa.drivers` is deprecated, use `mesa` instead
evaluation warning: `mesa.drivers` is deprecated, use `mesa` instead
evaluation warning: The option `hardware.opengl.package32' defined in `/nix/store/5rayqqq26jfw48hqbyxh2lxmbm12pq0l-source/nixos/configuration.nix' has been renamed to `hardware.graphics.package32'.
evaluation warning: The option `hardware.opengl.package' defined in `/nix/store/5rayqqq26jfw48hqbyxh2lxmbm12pq0l-source/nixos/configuration.nix' has been renamed to `hardware.graphics.package'.
evaluation warning: The option `hardware.opengl.driSupport32Bit' defined in `/nix/store/5rayqqq26jfw48hqbyxh2lxmbm12pq0l-source/nixos/configuration.nix' has been renamed to `hardware.graphics.enable32Bit'.
```

fixes #1058 and also fixes #970 