### PR TITLE
permissions: add plugin path example

### DIFF
--- a/pages/Configuring/Permissions.md
+++ b/pages/Configuring/Permissions.md
@@ -48,6 +48,10 @@ permission = /usr/bin/appsuite-.*, screencopy, allow
 ```
 Will allow any app whose path starts with `/usr/bin/appsuite-` to capture your screen without asking.
 
+```ini
+permission = /var/cache/hyprpm/$USER/hyprland-plugins/hyprexpo.so, plugin, allow
+```
+Will allow loading the hyprexpo plugin without asking.
 
 ### Permisision modes
 


### PR DESCRIPTION
Give an example to always allow loading a plugin from a hardcoded path.

Uses path `/var/cache/hyprpm/$USER/hyprland-plugins/pluginName.so` for demonstration