### PR TITLE
remove legacy renderer

### DIFF
--- a/pages/Crashes and Bugs/_index.md
+++ b/pages/Crashes and Bugs/_index.md
@@ -40,8 +40,7 @@ Diagnose the issue by what is in the log:
   monitor is bork.
 - Other -> see the coredump. Use `coredumpctl`, find the latest one's PID and do
   `coredumpctl info PID`.
-- failing on a driver (e.g. `radeon`) -> try compiling with
-  `make legacyrenderer`, if that doesn't help, report an issue.
+- failing on a driver (e.g. `radeon`) -> report an issue.
 - failing on `Hyprland` -> report an issue.
 
 ## Crashes not at launch

--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -345,12 +345,6 @@ epmi hyprland
 epmi hyprland-devel # If you want to use plugins
 ```
 
-or legacyrenderer version:
-
-```bash
-epmi hyprland-legacyrenderer
-```
-
 Ecosystem:
 
 ```bash
@@ -467,24 +461,17 @@ debug.
 
 See [Crashes and Bugs](../../Crashes-and-Bugs).
 
-## Custom installation (legacy renderer, etc)
+## Custom installation (debug build, etc)
 
 1. cd into the hyprland repo.
-2. for legacy renderer:
+2. for debug build:
 
 ```bash
-make legacyrenderer
+make debug
 sudo make install
 ```
 
-{{< callout type=info >}}
-
-_please note the legacy renderer may not support some graphical features._
-
-{{< /callout >}}
-
-3. Any other config: (replace `<PRESET>` with your preset: `release`, `debug`,
-   `legacyrenderer`, `legacyrendererdebug`)
+3. Any other config: (replace `<PRESET>` with your preset: `release`, `debug`)
 
 ```bash
 make <PRESET> && sudo cp ./build/Hyprland /usr/bin && sudo cp ./example/hyprland.desktop /usr/share/wayland-sessions
@@ -497,7 +484,6 @@ To apply custom build flags, you'll have to ditch make.
 Supported custom build flags on CMake:
 
 ```bash
-LEGACY_RENDERER - Compiles with the legacy renderer (see above)
 NO_XWAYLAND - Removes XWayland support
 NO_SYSTEMD - Removes systemd dependencies
 NO_UWSM - Does not install the hyprland-uwsm.desktop file

--- a/pages/Nix/Options & Overrides.md
+++ b/pages/Nix/Options & Overrides.md
@@ -16,7 +16,6 @@ be changed by setting the appropriate option to `true`/`false`.
 ```nix
 (pkgs.hyprland.override { # or inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland
   enableXWayland = true;  # whether to enable XWayland
-  legacyRenderer = false; # whether to use the legacy renderer (for old GPUs)
   withSystemd = true;     # whether to build with systemd support
 })
 ```


### PR DESCRIPTION
legacy renderer is now removed from hyprland. remove the mentions of it.

https://github.com/hyprwm/Hyprland/pull/10408