### PR TITLE
Documentation for hyprlang expression escaping.

### DIFF
--- a/pages/Hypr Ecosystem/hyprlang.md
+++ b/pages/Hypr Ecosystem/hyprlang.md
@@ -131,7 +131,7 @@ This may throw some errors if done incorrectly. Make sure that:
 
 ### Arithmetic escaping
 
-After VERSION, hyprlang allows for escaping the arithmetic expressions `{{a + b}}`
+After 0.6.4, hyprlang allows for escaping the arithmetic expressions `{{a + b}}`
 
 You need to use the `\` character for escaping these expression. They can be used on any of the starting positions of the expression braces.
 
@@ -148,16 +148,15 @@ So `\{{hello world}}` will turn into this: `{{hello world}}` without trying to p
 
 ### Escaping escapes
 
-After VERSION, you are able to escape any `\` that are used to escape other characters.
+After 0.6.4, you can escape any `\` that would have been used to escape other characters.
 
 For example:
-
-If you wanted to have an \ before a real expression
+If you want to have a `\` before a real expression
 ```ini
 someVariable = \\{{VAR1 + 10}}
 ```
 
-If you wanted to have an \ before any of the escapable charecters
+If you want to have an `\` before any of the escapable charecters
 ```ini
 someOtherVariable = \\{ hello \\} 
 ```

--- a/pages/Hypr Ecosystem/hyprlang.md
+++ b/pages/Hypr Ecosystem/hyprlang.md
@@ -133,7 +133,7 @@ This may throw some errors if done incorrectly. Make sure that:
 
 After VERSION, hyprlang allows for escaping the arithmetic expressions `{{a + b}}`
 
-You need to use the `\` charecter for escaping these expression. they can be used on any of the starting positions of the expression braces.
+You need to use the `\` character for escaping these expression. They can be used on any of the starting positions of the expression braces.
 
 Example:
 ```ini
@@ -143,20 +143,22 @@ someVariable = \{\{10 + 10}}
 ```
 
 This will cancel the expression, and instead just be the value. 
-All of the `\` that were used to escape will be removed from the value aswell.
-so `\{{hello world}}` will turn into this: `{{hello world}}` without trying to parse it as an expression.
+All of the `\` that were used to escape will be removed from the value as well.
+So `\{{hello world}}` will turn into this: `{{hello world}}` without trying to parse it as an expression.
 
 ### Escaping escapes
 
-After VERSION, you are able to escape any `\` that were used to escape other things.
-This is only needed if it otherwise would have escaped an escapable charecter.
+After VERSION, you are able to escape any `\` that are used to escape other characters.
 
 For example:
-```ini
-#If you wanted to have an \ before a real expression
-someVariable = \\{{VAR1 + 10}}
 
-#If you wanted to have an \ before any of the escapable chars
+If you wanted to have an \ before a real expression
+```ini
+someVariable = \\{{VAR1 + 10}}
+```
+
+If you wanted to have an \ before any of the escapable charecters
+```ini
 someOtherVariable = \\{ hello \\} 
 ```
 

--- a/pages/Hypr Ecosystem/hyprlang.md
+++ b/pages/Hypr Ecosystem/hyprlang.md
@@ -129,6 +129,38 @@ This may throw some errors if done incorrectly. Make sure that:
 - both sides either exist as numeric variables or are numeric themselves
 - you have spaces around the operator (**NOT** `{{a+b}}`)
 
+### Arithmetic escaping
+
+After VERSION, hyprlang allows for escaping the arithmetic expressions `{{a + b}}`
+
+You need to use the `\` charecter for escaping these expression. they can be used on any of the starting positions of the expression braces.
+
+Example:
+```ini
+$VAR = \{{10 + 10}}
+bind = MOD, KEY, exec, COMMAND "{\{10 + 10}}"
+someVariable = \{\{10 + 10}}
+```
+
+This will cancel the expression, and instead just be the value. 
+All of the `\` that were used to escape will be removed from the value aswell.
+so `\{{hello world}}` will turn into this: `{{hello world}}` without trying to parse it as an expression.
+
+### Escaping escapes
+
+After VERSION, you are able to escape any `\` that were used to escape other things.
+This is only needed if it otherwise would have escaped an escapable charecter.
+
+For example:
+```ini
+#If you wanted to have an \ before a real expression
+someVariable = \\{{VAR1 + 10}}
+
+#If you wanted to have an \ before any of the escapable chars
+someOtherVariable = \\{ hello \\} 
+```
+
+
 ## Developer documentation
 
 See the documentation at [hyprland.org/hyprlang](https://hyprland.org/hyprlang/).


### PR DESCRIPTION
This is documentation for the expression escaping that would be added from [this](https://github.com/hyprwm/hyprlang/pull/76) pull request.

It assumes the version number will be 0.6.4.