### PR TITLE
Edit Experimental Variables Section.

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -508,6 +508,8 @@ _Subcategory `group:groupbar:`_
 | --- | --- | --- | --- |
 | xx_color_management_v4 | enable color management protocol | bool | false |
 
+Since The release of `Mesa 25.1.1` settings below are no longer required, so just skip.
+
 Requires a client with `frog-color-management-v1` or `xx-color-management-v4` support like gamescope or https://github.com/Zamundaaa/VK_hdr_layer
 
 Steam:


### PR DESCRIPTION
`ENABLE_HDR_WSI` and `DXVK_HDR=1` no longer necessary since the release of Mesa 25.1.1.