### PR TITLE
Update Systemd-start.md - include libnewt in Arch Installation

### DIFF
--- a/pages/Useful Utilities/Systemd-start.md
+++ b/pages/Useful Utilities/Systemd-start.md
@@ -14,7 +14,7 @@ title: Systemd startup
 uwsm is available in Arch official repositories.
 
 ```sh
-pacman -S uwsm
+pacman -S uwsm libnewt
 ```
 
 {{% /details %}}


### PR DESCRIPTION
Selection menu fails to start unless [whiptail](https://github.com/Vladimir-csp/uwsm#:~:text=whiptail%20(optional%2C%20for%20select%20feature%3B%20from%20whiptail%20or%20libnewt%20package)) is provided. 

