### PR TITLE
alttab : add altzorder top

### DIFF
--- a/pages/Configuring/Uncommon-tips-&-tricks.md
+++ b/pages/Configuring/Uncommon-tips-&-tricks.md
@@ -315,7 +315,7 @@ address=$(hyprctl -j clients | jq -r 'sort_by(.focusHistoryID) | .[] | select(.w
 	      awk -F"\t" '{print $1}')
 
 if [ -n "$address" ] ; then
-    hyprctl -q dispatch focuswindow address:$address
+    hyprctl --batch -q "dispatch focuswindow address:$address;dispatch alterzorder top"
 fi
 
 hyprctl -q dispatch submap reset


### PR DESCRIPTION
currently if 1 floating window is behind another floating window, if you select the window behind it focuses it but it stays behind.
this pr fixes this issue