### PR TITLE
Update hyprpaper.md

### DIFF
--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -138,23 +138,41 @@ unload old sequence.
 You can also use this simple `reload` functionality to randomize your wallpaper. Using a simple script like so would do it very easily:
 
 ```bash
-#!/usr/bin/env bash
+#!/bin/bash
+ATTEMPTS=0
+MAX_NUM=10
+FILES=()
+WALLPAPER_DIR="/usr/share/backgrounds"
+CURRENT_WALL=$(hyprctl --instance 0 hyprpaper listloaded)
+WALLPAPER=""
 
-WALLPAPER_DIR="$HOME/wallpapers/"
-CURRENT_WALL=$(hyprctl hyprpaper listloaded)
+while true; do
+    ((ATTEMPTS++))
+    echo "Attempt #$ATTEMPTS"
 
-# Get a random wallpaper that is not the current one
-WALLPAPER=$(find "$WALLPAPER_DIR" -type f ! -name "$(basename "$CURRENT_WALL")" | shuf -n 1)
-MIME_TYPE=$(file --mime-type -b "$WALLPAPER")
+    if (( ATTEMPTS > MAX_NUM )); then
+        notify-send "Error: we tried to set the following files: ${FILES[*]}"
+        exit 1
+    fi
 
-# if the mimetype is not an image, it probably won't load :-)
-if [[ !"$MIME_TYPE" =~ ^image/ ]]; then
-notify-send "WARNING" "The selected file '$WALLPAPER' is not an image (MIME type: $MIME_TYPE). Bailing out."
-exit 1;
-fi
+    WALLPAPER=$(find "$WALLPAPER_DIR" -type f ! -name "$(basename "$CURRENT_WALL")" | shuf -n 1)
+    if [[ -z "$WALLPAPER" ]]; then
+        notify-send "Error: No suitable wallpapers found."
+        exit 1
+    fi
 
-# Apply the selected wallpaper
-hyprctl hyprpaper reload ,"$WALLPAPER"
+    MIME_TYPE=$(file --mime-type -b "$WALLPAPER")
+    if [[ ! "$MIME_TYPE" =~ ^image/ ]]; then
+        echo "$WALLPAPER - $MIME_TYPE"
+        FILES+=("$WALLPAPER")
+        notify-send "WARNING" "The selected file '$WALLPAPER' is not an image (MIME type: $MIME_TYPE)."
+    else
+        echo "Setting: $WALLPAPER"
+        # Apply the selected wallpaper
+        hyprctl --instance 0 hyprpaper reload ,"$WALLPAPER"
+        break
+    fi
+done
 ```
 
 For a multiple-monitor setup, you can use this modified script that randomizes the wallpaper of your currently focused monitor:

--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -145,6 +145,13 @@ CURRENT_WALL=$(hyprctl hyprpaper listloaded)
 
 # Get a random wallpaper that is not the current one
 WALLPAPER=$(find "$WALLPAPER_DIR" -type f ! -name "$(basename "$CURRENT_WALL")" | shuf -n 1)
+MIME_TYPE=$(file --mime-type -b "$WALLPAPER")
+
+# if the mimetype is not an image, it probably won't load :-)
+if [[ !"$MIME_TYPE" =~ ^image/ ]]; then
+notify-send "WARNING" "The selected file '$WALLPAPER' is not an image (MIME type: $MIME_TYPE). Bailing out."
+exit 1;
+fi
 
 # Apply the selected wallpaper
 hyprctl hyprpaper reload ,"$WALLPAPER"

--- a/pages/Hypr Ecosystem/hyprpaper.md
+++ b/pages/Hypr Ecosystem/hyprpaper.md
@@ -138,7 +138,7 @@ unload old sequence.
 You can also use this simple `reload` functionality to randomize your wallpaper. Using a simple script like so would do it very easily:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 ATTEMPTS=0
 MAX_NUM=10
 FILES=()


### PR DESCRIPTION
Add a check for mime-type in documentation for "Get a random wallpaper that is not the current one".  

This prevents hyprpaper from trying to load a .git directory, or other mime types and crashing.