### PR TITLE
Nix/Hyprland on NixOS: use dconf nix configuration

### DIFF
--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -154,10 +154,16 @@ relevant section in [Hyprland on Home Manager](../Hyprland-on-Home-Manager).
 If you prefer not to use Home Manager, you can also resolve the issues with GTK
 themes using dconf like so:
 
-```ini {filename="hyprland.conf"}
-exec-once = dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"
-exec-once = dconf write /org/gnome/desktop/interface/icon-theme "'Flat-Remix-Red-Dark'"
-exec-once = dconf write /org/gnome/desktop/interface/document-font-name "'Noto Sans Medium 11'"
-exec-once = dconf write /org/gnome/desktop/interface/font-name "'Noto Sans Medium 11'"
-exec-once = dconf write /org/gnome/desktop/interface/monospace-font-name "'Noto Sans Mono Medium 11'"
+```nix {filename="configuration.nix"}
+programs.dconf.profiles.user.databases = [
+  {
+    settings."org/gnome/desktop/interface" = {
+      gtk-theme = "Adwaita";
+      icon-theme = "Flat-Remix-Red-Dark";
+      font-name = "Noto Sans Medium 11";
+      document-font-name = "Noto Sans Medium 11";
+      monospace-font-name = "Noto Sans Mono Medium 11";
+    };
+  }
+];
 ```


### PR DESCRIPTION
I only found out about this today, and it's a much better solution compared to adding dconf commands to exec-once

Tested on my end, works gr8