### PR TITLE
xdg-desktop-portal-hyprland: use `sh` instead of `bash`

### DIFF
--- a/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
+++ b/pages/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
@@ -117,7 +117,7 @@ Hyprland will not work (e.g. window sharing).
 For a nuclear option, you can use this script and `exec-once` it:
 
 ```sh
-#!/usr/bin/env bash
+#!/bin/sh
 sleep 1
 killall -e xdg-desktop-portal-hyprland
 killall xdg-desktop-portal


### PR DESCRIPTION
Nothing bash specific is used so we might use the basic shell