### PR TITLE
Configuring/index: Fix broken Start Page link

### DIFF
--- a/pages/Configuring/_index.md
+++ b/pages/Configuring/_index.md
@@ -15,4 +15,4 @@ It links to other pages where necessary, and will walk you through:
 
 It also contains some sample configurations you can take inspiration from.
 
-Start with [the Start Page](./Start).
+Start with [the Start Page](./Configuring/Start).


### PR DESCRIPTION
The link to go from the root/index [Configuring page](https://wiki.hypr.land/Configuring/) to the Start page is broken. Simple fix.