### PR TITLE
fix path to `Variables` page

### DIFF
--- a/pages/Configuring/Start.md
+++ b/pages/Configuring/Start.md
@@ -27,7 +27,7 @@ The default config is not complete and does not list all the options / features
 of Hyprland. Please refer to this wiki page and the pages linked further down
 here for full configuration instructions.
 
-**Make sure to read the [Variables](../Variables) page as well**. It covers all
+**Make sure to read the [Variables](./Variables) page as well**. It covers all
 the toggleable / numerical options.
 
 {{< /callout >}}


### PR DESCRIPTION
The `Variables` link on `Start` page leads to 404, as the Start page and Variables page are on same dir, the reference `../Variables` won't work. Simply removing `.` would make the path correct