### PR TITLE
Path fixes on `Start` page

### DIFF
--- a/pages/Configuring/Start.md
+++ b/pages/Configuring/Start.md
@@ -27,7 +27,7 @@ The default config is not complete and does not list all the options / features
 of Hyprland. Please refer to this wiki page and the pages linked further down
 here for full configuration instructions.
 
-**Make sure to read the [Variables](../Variables) page as well**. It covers all
+**Make sure to read the [Variables](./Variables) page as well**. It covers all
 the toggleable / numerical options.
 
 {{< /callout >}}
@@ -39,11 +39,11 @@ See the [hyprlang page](../../Hypr-Ecosystem/hyprlang).
 ## Basic configuring
 
 To configure Hyprland's options, animations, styling, etc. see
-[Variables](../Variables).
+[Variables](./Variables).
 
 ## Advanced configuring
 
 Some keywords (binds, curves, execs, monitors, etc.) are not variables but
 define special behavior.
 
-See all of them in [Keywords](../Keywords) and the sidebar.
+See all of them in [Keywords](./Keywords) and the sidebar.


### PR DESCRIPTION
As `Start` page and pages it references like `Keywords` & `Variables` are on same directory, `./` should be used.