### PR TITLE
Fix link to Useful Utilities

### DIFF
--- a/pages/_index.md
+++ b/pages/_index.md
@@ -19,7 +19,7 @@ A Wayland compositor is a fully autonomous Display Server, like Xorg itself. It
 is **not** possible to mix'n'match Wayland compositors like you could on Xorg
 with window managers and compositors. It is also not entirely possible, nor
 recommended, to try and use all Xorg applications on Wayland. See
-[this page](../Useful-Utilities) for a list of recommended Wayland
+[this page](../Useful-Utilities/) for a list of recommended Wayland
 native/compatible programs.
 
 Wayland **compositors** should not be confused with Xorg **window managers**.


### PR DESCRIPTION
Without the trailing `/`, all links under "Useful Utilities" lead to a 404 page.