### PR TITLE
nvidia: change wording for multi-monitor with hybrid graphics

### DIFF
--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -208,11 +208,12 @@ experimental support for Chromium, however there has not been much success.
 ## Other issues
 
 ### Multi-monitor with hybrid graphics
+If you experience issues with multi-monitor setup on a hybrid graphics device
+(a laptop with both an Intel and an Nvidia GPU), switching to discrete-only mode may help:
 
-On a hybrid graphics device (a laptop with both an Intel and an Nvidia GPU), you
-will need to remove the `optimus-manager` package if installed (disabling the
-service does not work). You also need to change your BIOS settings from hybrid
-graphics to discrete graphics.
+1. Remove the `optimus-manager` package if installed (disabling the
+   service does not work).
+2. Change your BIOS settings from hybrid graphics to discrete graphics.
 
 ### Flickering in XWayland games
 


### PR DESCRIPTION
It feels weird to see this section, since it implies that multi-monitor doesn't work on hybrid graphics. 

But I'm writing this PR from a laptop with hybrid graphics (nvidia+ intel) and 2 monitors connected.
In fact, I can't disable hybrid since one of the monitors is connected through thunderbolt which wouldn't function without iGPU.

So TL;DR:
Multi-monitor on hybrid graphics works perfectly fine. Reworded a bit, so it doesn't imply otherwise. Maybe better to remove the section altogether? 
It was originally added in #112, but it's not clear how my setup is different, except that 2 years have passed since.