### PR TITLE
treewide: add missing curlies to some Nix language codeblocks

### DIFF
--- a/pages/Getting Started/Installation.md
+++ b/pages/Getting Started/Installation.md
@@ -83,7 +83,9 @@ In case of errors you can downgrade easily with [downgrade](https://github.com/a
 Enable Hyprland in your NixOS configuration:
 
 ```nix
-programs.hyprland.enable = true;
+{
+  programs.hyprland.enable = true;
+}
 ```
 
 For more details, read the [Nix page](../../Nix).

--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -211,12 +211,14 @@ defined in your NixOS module, you can now do so as long as you're running
 or later by setting your `package` and `portalPackage` to `null`.
 
 ```nix {filename="home.nix"}
-wayland.windowManager.hyprland = {
-  enable = true;
-  # set the Hyprland and XDPH packages to null to use the ones from the NixOS module
-  package = null;
-  portalPackage = null;
-};
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    # set the Hyprland and XDPH packages to null to use the ones from the NixOS module
+    package = null;
+    portalPackage = null;
+  };
+}
 ```
 
 Make sure **not** to mix versions of Hyprland and XDPH.
@@ -233,7 +235,9 @@ services. This is the most common with user-configured services such as
 To fix it, add to your config:
 
 ```nix {filename="home.nix"}
-wayland.windowManager.hyprland.systemd.variables = ["--all"];
+{
+  wayland.windowManager.hyprland.systemd.variables = ["--all"];
+}
 ```
 
 This setting will produce the following entry in the Hyprland config:

--- a/pages/Nix/Hyprland on NixOS.md
+++ b/pages/Nix/Hyprland on NixOS.md
@@ -155,15 +155,17 @@ If you prefer not to use Home Manager, you can also resolve the issues with GTK
 themes using dconf like so:
 
 ```nix {filename="configuration.nix"}
-programs.dconf.profiles.user.databases = [
-  {
-    settings."org/gnome/desktop/interface" = {
-      gtk-theme = "Adwaita";
-      icon-theme = "Flat-Remix-Red-Dark";
-      font-name = "Noto Sans Medium 11";
-      document-font-name = "Noto Sans Medium 11";
-      monospace-font-name = "Noto Sans Mono Medium 11";
-    };
-  }
-];
+{
+  programs.dconf.profiles.user.databases = [
+    {
+      settings."org/gnome/desktop/interface" = {
+        gtk-theme = "Adwaita";
+        icon-theme = "Flat-Remix-Red-Dark";
+        font-name = "Noto Sans Medium 11";
+        document-font-name = "Noto Sans Medium 11";
+        monospace-font-name = "Noto Sans Mono Medium 11";
+      };
+    }
+  ];
+}
 ```

--- a/pages/Nvidia/_index.md
+++ b/pages/Nvidia/_index.md
@@ -247,7 +247,9 @@ you haven't already.
 For Nix users, the equivalent of the above is
 
 ```nix {filename="configuration.nix"}
-hardware.nvidia.powerManagement.enable = true;
+{
+  hardware.nvidia.powerManagement.enable = true;
+}
 ```
 
 {{< callout >}}

--- a/pages/Useful Utilities/Systemd-start.md
+++ b/pages/Useful Utilities/Systemd-start.md
@@ -22,7 +22,9 @@ pacman -S uwsm libnewt
 {{% details title="Nix/NixOS" closed="true" %}}
 
 ```nix
-programs.hyprland.withUWSM  = true;
+{
+  programs.hyprland.withUWSM  = true;
+}
 ```
 
 The above option generates a new desktop entry, `hyprland-uwsm.desktop`, which will be available in display managers.
@@ -34,7 +36,9 @@ For more info, read the [option](https://search.nixos.org/options?channel=unstab
 If you use the [Home Manager module](../../Nix/Hyprland-on-Home-Manager), make sure to disable the systemd integration, as it conflicts with uwsm.
 
 ```nix
-wayland.windowManager.hyprland.systemd.enable = false;
+{
+  wayland.windowManager.hyprland.systemd.enable = false;
+}
 ```
 
 {{< /callout >}}


### PR DESCRIPTION
fixes syntax highlighting and is more correct 👍🏽 

before it looked like below in a few places 👇🏽 
![image](https://github.com/user-attachments/assets/68d14787-5ee7-4a56-b63d-7e80179fc6d0)

maybe i missed some but I think I caught em. Checked each Nix codeblock with 
```sh
git grep \`\`\`nix
```
but I could've left one who knows