### PR TITLE
Remove spaces in rgba and rgb decimal value's and added explanation

### DIFF
--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -34,6 +34,7 @@ You have 3 options:
 
 rgba(), e.g. `rgba(b3ff1aee)`, or the decimal equivalent `rgba(179,255,26,0.933)`
 (decimal rgba/rgb values should have no spaces between numbers)
+
 rgb(), e.g. `rgb(b3ff1a)`, or the decimal equivalent  `rgb(179,255,26)`
 
 legacy, e.g. `0xeeb3ff1a` -> ARGB order

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -33,6 +33,7 @@ the layout pages and not here. (See the Sidebar for Dwindle and Master layouts)
 You have 3 options:
 
 rgba(), e.g. `rgba(b3ff1aee)`, or the decimal equivalent `rgba(179,255,26,0.933)`
+
 (decimal rgba/rgb values should have no spaces between numbers)
 
 rgb(), e.g. `rgb(b3ff1a)`, or the decimal equivalent  `rgb(179,255,26)`

--- a/pages/Configuring/Variables.md
+++ b/pages/Configuring/Variables.md
@@ -32,9 +32,9 @@ the layout pages and not here. (See the Sidebar for Dwindle and Master layouts)
 
 You have 3 options:
 
-rgba(), e.g. `rgba(b3ff1aee)`, or the decimal equivalent `rgba(179, 255, 26, 0.933)`
-
-rgb(), e.g. `rgb(b3ff1a)`, or the decimal equivalent  `rgb(179, 255, 26)`
+rgba(), e.g. `rgba(b3ff1aee)`, or the decimal equivalent `rgba(179,255,26,0.933)`
+(decimal rgba/rgb values should have no spaces between numbers)
+rgb(), e.g. `rgb(b3ff1a)`, or the decimal equivalent  `rgb(179,255,26)`
 
 legacy, e.g. `0xeeb3ff1a` -> ARGB order
 


### PR DESCRIPTION
Hyprland does not work with the decimal version of rgba() and rgb() when they have spaces inbetween the numbers, so here a change to the wiki to explain this as its a little confusing at the moment, maybe im stupid but i feel like this is a good change (don't mind the commit descriptions)