### PR TITLE
UWSM: Fix hyprland's UWSM entry name

### DIFF
--- a/pages/Useful Utilities/Systemd-start.md
+++ b/pages/Useful Utilities/Systemd-start.md
@@ -75,7 +75,7 @@ If you want to bypass compositor selection menu and launch Hyprland directly, us
 
 ```
 if uwsm check may-start; then
-    exec uwsm start hyprland.desktop
+    exec uwsm start hyprland-uwsm.desktop
 fi
 ```
 


### PR DESCRIPTION
Not sure if this is only on my system or true for everyone, but hyprland.desktop does not exist on my computer and the correct entry is hyprland-uwsm.desktop.

Thus creating this pull request in case others might get locked out by their shell profile because of this.