### PR TITLE
Getting Started/Master Tutorial: Update Launching Hyprland section - list of compatible login managers

### DIFF
--- a/pages/Getting Started/Master-Tutorial.md
+++ b/pages/Getting Started/Master-Tutorial.md
@@ -69,7 +69,7 @@ list:
 - GDM → Works with the caveat of crashing Hyprland on the first launch.
 - greetd → Works flawlessly, especially with
   [ReGreet](https://github.com/rharish101/ReGreet).
-- ly → Works poorly.
+- ly → Works flawlessly.
 
 ## DE-like pre-configured setups
 


### PR DESCRIPTION
Hello. Recently new to Hyprland and in my search for a login manager I ended up choosing [ly](https://github.com/fairyglade/ly). The [Launching Hyprland](https://wiki.hypr.land/Getting-Started/Master-Tutorial/#launching-hyprland) section of the Master Tutorial states that for login managers:

> - ly -> Works poorly.

I've opened this PR to see whether we think this is still the case and a proposed change based on current findings/experiences. From the wiki I initially uninstalled ly assuming it would be difficult to setup and get working, but after a bit of digging I found a [Reddit thread](https://www.reddit.com/r/NixOS/comments/17ngiji/how_do_i_get_ly_working_on_hyprland/) from 2 years ago where another Hyprland user found ly to be working out of the box. After reinstalling and giving it a go I also had a similar experience. It was really a matter of installing through Pacman then enabling & starting via `systemctl`. 

I will note that that I haven't done extensive customisation or configuration as I didn't feel the need to beyond changing the background animation.

Additionally the [ly README](https://github.com/fairyglade/ly?tab=readme-ov-file#supported-wayland-environments) lists Hyprland as a supported Wayland environment. Would be great to the list of login managers updated to include ly as a compatible login manager that now has much better support for Hyprland. Thank you.