### PR TITLE
Configuring/Binds: remove extra commas for multiple bind

### DIFF
--- a/pages/Configuring/Binds.md
+++ b/pages/Configuring/Binds.md
@@ -161,8 +161,8 @@ one combination, e.g.:
 
 ```ini
 # to switch between windows in a floating workspace
-bind = SUPER, Tab, cyclenext,           # change focus to another window
-bind = SUPER, Tab, bringactivetotop,    # bring it to the top
+bind = SUPER, Tab, cyclenext           # change focus to another window
+bind = SUPER, Tab, bringactivetotop    # bring it to the top
 ```
 
 The keybinds will be executed in the order they were created. (top to bottom)


### PR DESCRIPTION
adding commas for multiple bind passes as valid config but does not work as expected.

ref: https://wiki.hypr.land/0.49.0/Configuring/Uncommon-tips--tricks/#minimize-windows-using-special-workspaces