### PR TITLE
Update Astal urls

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -92,8 +92,8 @@ Below are three popular choices in alphabetical order.
 - [AGS](https://aylur.github.io/ags/) (Aylur's GTK Shell) is a scaffolding tool for Astal and TypeScript/Javascript(X).
 In simple words, it eases creation of Astal projects in those languages.
 
-To get started with Astal, see its [installation instructions](https://aylur.github.io/astal/guide/getting-started/installation)
-and [examples](https://aylur.github.io/astal/guide/getting-started/supported-languages).
+To get started with Astal, see its [installation instructions](https://aylur.github.io/astal/guide/installation)
+and [examples](https://aylur.github.io/astal/guide/introduction#supported-languages).
 For AGS, see its [Quick start](https://aylur.github.io/ags/guide/quick-start.html) page.
 
 ### Advantages


### PR DESCRIPTION
The install guide points to a 404. The project scope recently changed slightly, and the structure of the Astal docs has also been updated as a result.