### PR TITLE
Screensharing: add bitdepth information

### DIFF
--- a/pages/Useful Utilities/Screen-Sharing.md
+++ b/pages/Useful Utilities/Screen-Sharing.md
@@ -11,6 +11,10 @@ Make sure you have `pipewire`, `wireplumber` and
 [`xdg-desktop-portal-hyprland`](../../Hypr-Ecosystem/xdg-desktop-portal-hyprland)
 installed, enabled and running if you don't have them yet.
 
+Ensure that the `bitdepth` set in your configuration 
+matches that of your physical monitor.
+See [Monitors](../Configuring/Monitors.md).
+
 ## Screensharing
 
 Read


### PR DESCRIPTION
`bitdepth` setting on hyprland configuration should match that of the physical monitor. Screenshare was not working for me for a long time because of this simple mismatch. Many (old) sources on reddit and github mention changing bitdepth as one of the first options for fixing the problem when in reality it could be caused by something else.