### PR TITLE
Nix/Hyprland-on-Home-Manager: add information on how to export variables when using NixOS with UWSM

### DIFF
--- a/pages/Nix/Hyprland on Home Manager.md
+++ b/pages/Nix/Hyprland on Home Manager.md
@@ -247,3 +247,16 @@ exec-once = dbus-update-activation-environment --systemd --all
 ```
 
 Make sure to use the above command if you do not use the Home Manager module.
+
+#### NixOS UWSM
+
+If you're using the NixOS module with UWSM (`programs.hyprland.withUWSM =
+true`), you can [set environment variables][uwsm-env] like this:
+
+```nix {filename="home.nix"}
+{
+  xdg.configFile."uwsm/env".source = "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"; 
+}
+```
+
+[uwsm-env]: https://github.com/Vladimir-csp/uwsm?tab=readme-ov-file#4-environments-and-shell-profile "Environments and shell profile - UWSM"


### PR DESCRIPTION
When using the NixOS module with UWSM, one should not enable the Home Manager module's systemd integration, as it conflicts with UWSM. Thus, configuring `wayland.windowManager.hyprland.systemd.variables` will not work, as it only takes effect when `wayland.windowMarager.hyprland.systemd.enable == true`.

To ensure that the environment variables for user services are set correctly even if they start before Hyprland is started by UWSM, `${XDG_CONFIG_HOME}/uwsm/env` should be populated. Since UWSM sources that file, we can use the session variables script that Home Manager generates under the hood verbatim.