### PR TITLE
Add noinitialfocus to flameshot rules in FAQ

### DIFF
--- a/pages/FAQ/_index.md
+++ b/pages/FAQ/_index.md
@@ -95,6 +95,7 @@ windowrule = noanim, class:^(flameshot)$
 windowrule = float, class:^(flameshot)$
 windowrule = move 0 0, class:^(flameshot)$
 windowrule = pin, class:^(flameshot)$
+windowrule = noinitialfocus, class:^(flameshot)$
 # set this to your leftmost monitor id, otherwise you have to move your cursor to the leftmost monitor
 # before executing flameshot
 windowrule = monitor 1, class:^(flameshot)$


### PR DESCRIPTION
Adds `windowrule = noinitialfocus, class:^(flameshot)$` to the list of advised rules for using flameshot in the FAQ. Without this rule, flameshot will kick any fullscreen windows out of fullscreen when taking a screenshot.