### PR TITLE
Configuring/Window Rules: Minor consistency fixes, punctuation and rephrasing

### DIFF
--- a/pages/Configuring/Window-Rules.md
+++ b/pages/Configuring/Window-Rules.md
@@ -107,7 +107,7 @@ Static rules are evaluated once when the window is opened and never again. This 
 
 {{< callout type=warning >}}
 
-It is not possible to `float` (or any other of the static rule) a window based on a change in the `title` after the window has been created. This applies to all static rules listed here.
+It is not possible to `float` (or any other static rule) a window based on a change in the `title` after the window has been created. This applies to all static rules listed here.
 
 {{< /callout >}}
 


### PR DESCRIPTION
- regex -> RegEx
- Add link for Google's RE2
- Add capitals and periods for descriptions in tables
- Add `<br>` to break up longer paragraphs for legibility
- `x y` --> `w h` in maxsize and minsize to be consistent with #1147 
- Add link for nearest neighbor filtering
- Enclose notes under dynamic rules and window rule options in a callout