### PR TITLE
Configuring and Getting Started/index: fold by default

### DIFF
--- a/pages/Configuring/_index.md
+++ b/pages/Configuring/_index.md
@@ -1,8 +1,6 @@
 ---
 weight: 3
 title: Configuring
-sidebar:
-  open: true
 ---
 
 This section is all about the configuring (aka ricing) of your Hyprland experience.

--- a/pages/Getting Started/_index.md
+++ b/pages/Getting Started/_index.md
@@ -1,8 +1,6 @@
 ---
 weight: 2
 title: Getting Started
-sidebar:
-  open: true
 ---
 
 If you are coming to Hyprland for the first time, read the


### PR DESCRIPTION
This sets both categories to start as folded by default, eliminating the unwanted behavior of them unfolding every time the user clicks on a category.

Resolves #826 