### PR TITLE
Useful Utilities/File-Managers.md: fix Thunar link

### DIFF
--- a/pages/Useful Utilities/File-Managers.md
+++ b/pages/Useful Utilities/File-Managers.md
@@ -15,7 +15,7 @@ title: File Managers
   - [nemo-terminal](https://github.com/linuxmint/nemo-extensions/tree/master/nemo-terminal): Embedded terminal window.
 - [pcmanfm-qt](https://github.com/lxqt/pcmanfm-qt): File manager by LXQt.
 - [pcmanfm](https://github.com/lxde/pcmanfm): File manager by LXDE.
-- [thunar](https://github.com/neilbrown/thunar): File manager by XFCE.
+- [thunar](https://gitlab.xfce.org/xfce/thunar): File manager by XFCE.
 
 ## TUI
 


### PR DESCRIPTION
The linked GitHub repo was last updated 14 years ago, and the pacman thunar package is using this gitlab link, if I'm not mistaken (https://gitlab.archlinux.org/archlinux/packaging/packages/thunar/-/blob/main/PKGBUILD).