### PR TITLE
Configuring/Window Rules: Warn about evaluation order

### DIFF
--- a/content/Configuring/Window-Rules.md
+++ b/content/Configuring/Window-Rules.md
@@ -17,6 +17,13 @@ example, in the case of `kitty`:
 
 {{< /callout >}}
 
+{{< callout type=warning >}}
+
+Rules are evaluated top to bottom, so the order they're written in does matter!  
+More info in [Notes](#notes)
+
+{{< /callout >}}
+
 ## Window Rules
 
 You can set window rules to achieve different window behaviors based


### PR DESCRIPTION
Resolves: #1140 

This assumes that *ALL* types of window rules are evaluated from top to bottom, correct me if I'm wrong.