### PR TITLE
rofi wayland support

### DIFF
--- a/content/Useful Utilities/App-Launchers.md
+++ b/content/Useful Utilities/App-Launchers.md
@@ -8,9 +8,9 @@ title: App launchers
 Wofi is a GTK-based customizable launcher for Wayland.
 [SourceHut](https://hg.sr.ht/~scoopta/wofi).
 
-## Rofi (Wayland fork)
+## Rofi
 
-Rofi, but with Wayland support. [GitHub](https://github.com/lbonn/rofi).
+Rofi, A window switcher, Application launcher and dmenu replacement. supports wayland since 2025 [GitHub](https://github.com/davatorium/rofi).
 
 ## bemenu
 

--- a/content/Useful Utilities/App-Launchers.md
+++ b/content/Useful Utilities/App-Launchers.md
@@ -10,7 +10,7 @@ Wofi is a GTK-based customizable launcher for Wayland.
 
 ## Rofi
 
-Rofi, A window switcher, Application launcher and dmenu replacement. supports wayland since 2025 [GitHub](https://github.com/davatorium/rofi).
+Rofi, a window switcher, application launcher and `dmenu` replacement. supports Wayland since 2025. [GitHub](https://github.com/davatorium/rofi).
 
 ## bemenu
 


### PR DESCRIPTION
rofi supports wayland natively since 2025. old repo will be archived.