### PR TITLE
Update Uncommon-tips-&-tricks.md - gamemode.sh 

### DIFF
--- a/content/Configuring/Uncommon-tips-&-tricks.md
+++ b/content/Configuring/Uncommon-tips-&-tricks.md
@@ -230,10 +230,10 @@ HYPRGAMEMODE=$(hyprctl getoption animations:enabled | awk 'NR==1{print $2}')
 if [ "$HYPRGAMEMODE" = 1 ] ; then
     hyprctl --batch "\
         keyword animations:enabled 0;\
-	keyword animation borderangle,0; \
+        keyword animation borderangle,0; \
         keyword decoration:shadow:enabled 0;\
         keyword decoration:blur:enabled 0;\
-	keyword decoration:fullscreen_opacity 1;\
+	    keyword decoration:fullscreen_opacity 1;\
         keyword general:gaps_in 0;\
         keyword general:gaps_out 0;\
         keyword general:border_size 1;\

--- a/content/Configuring/Uncommon-tips-&-tricks.md
+++ b/content/Configuring/Uncommon-tips-&-tricks.md
@@ -230,15 +230,22 @@ HYPRGAMEMODE=$(hyprctl getoption animations:enabled | awk 'NR==1{print $2}')
 if [ "$HYPRGAMEMODE" = 1 ] ; then
     hyprctl --batch "\
         keyword animations:enabled 0;\
+	keyword animation borderangle,0; \
         keyword decoration:shadow:enabled 0;\
         keyword decoration:blur:enabled 0;\
+	keyword decoration:fullscreen_opacity 1;\
         keyword general:gaps_in 0;\
         keyword general:gaps_out 0;\
         keyword general:border_size 1;\
         keyword decoration:rounding 0"
+    hyprctl notify 1 5000 "rgb(40a02b)" "Gamemode [ON]"
     exit
+else
+    hyprctl notify 1 5000 "rgb(d20f39)" "Gamemode [OFF]"
+    hyprctl reload
+    exit 0
 fi
-hyprctl reload
+exit 1
 ```
 
 Edit to your liking of course. If animations are enabled, it disables all the


### PR DESCRIPTION
Update hyprland docs example for gamemode.sh to incude:
- `animation borderangle,0` <- Disable border animation
  fixes loop style for borderangle stress on CPU/Battery (further read: hyprwm/hyprland#4779 )
- `keyword decoration:fullscreen_opacity 1;` 
   Games in fullscreen would probably want this set
- `hyprnotify` notification on gamemode state on toggle
- exit codes reflect successfull state change (0) or error (!= 0) 