### PR TITLE
Master-Layout: document `previous` param value for `focusmaster` command

### DIFF
--- a/content/Configuring/Master-Layout.md
+++ b/content/Configuring/Master-Layout.md
@@ -37,7 +37,7 @@ _category name `master`_
 | command | description | params |
 | --- | --- | --- |
 | swapwithmaster | swaps the current window with master. If the current window is the master, swaps it with the first child. | either `master` (new focus is the new master window), `child` (new focus is the new child) or `auto` (which is the default, keeps the focus of the previously focused window). Adding `ignoremaster` will ignore this dispatcher if master is already focused. |
-| focusmaster | focuses the master window. | either `master` (focus stays at master, even if it was selected before) or `auto` (which is the default, if the current window is the master, focuses the first child.) |
+| focusmaster | focuses the master window. | either `master` (focus stays on master), `auto` (default; focus first non-master window if already on master) or `previous` (remember current window when focusing master, if already on master, focus previous or fallback to `auto`). |
 | cyclenext | focuses the next window respecting the layout | either `loop` (allow looping from the bottom of the pile back to master) or `noloop` (force stop at the bottom of the pile, like in DWM). `loop` is the default if left blank. |
 | cycleprev | focuses the previous window respecting the layout | either `loop` (allow looping from master to the bottom of the pile) or `noloop` (force stop at master, like in DWM). `loop` is the default if left blank. |
 | swapnext | swaps the focused window with the next window respecting the layout | either `loop` (allow swapping the bottom of the pile and master) or `noloop` (do not allow it, like in DWM). `loop` is the default if left blank. |


### PR DESCRIPTION
Update `focusmaster` dispatcher command's params section to include the new `previous` parameter value introduced in https://github.com/hyprwm/Hyprland/pull/11361