### PR TITLE
Fix syntax causing hugo serve error

### DIFF
--- a/content/Contributing and Debugging/Issue-Guidelines.md
+++ b/content/Contributing and Debugging/Issue-Guidelines.md
@@ -38,7 +38,7 @@ For bugs:
 - If a discussion is a Hyprland problem, but cannot be tied to Hyprland in a clear way, or is not reproducible, it stays a discussion until that changes.
 - If a discussion is reproducible, a member of Hyprland promotes the discussion to an issue by opening an issue with the key information and links the original discussion.
 
-{{< callout type=info>}}
+{{< callout type=info >}}
 To get logs for your bug please see [Crashes and Bugs](https://wiki.hypr.land/Crashes-and-Bugs/)
 {{< /callout >}}
 


### PR DESCRIPTION
Fixes the following error which occurs when running `hugo serve` (v0.148.2):

```Error: error building site: process: readAndProcessContent: ".../hyprland-wiki/content/Contributing and
Debugging/Issue-Guidelines.md:42:1": got positional parameter 'To'. Cannot mix named and positional parameters```