### PR TITLE
Update Uncommon-tips-&-tricks.md

### DIFF
--- a/content/Configuring/Uncommon-tips-&-tricks.md
+++ b/content/Configuring/Uncommon-tips-&-tricks.md
@@ -357,7 +357,7 @@ line="$1"
 IFS=$'\t' read -r addr _ <<< "$line"
 dim=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}
 
-grim -t png -l 0 -w "$addr" ~.config/hypr/scripts/alttab/preview.png
+grim -t png -l 0 -w "$addr" ~/.config/hypr/scripts/alttab/preview.png
 chafa --animate false -s "$dim" "$XDG_CONFIG_HOME/hypr/scripts/alttab/preview.png"
 ```
 


### PR DESCRIPTION
Fixed a typo in the "Alt Tab Preview" script.

Before the fix the preview images didn't work.