### PR TITLE
improve fuzzel clipboard cmd

### DIFF
--- a/content/Useful Utilities/Clipboard-Managers.md
+++ b/content/Useful Utilities/Clipboard-Managers.md
@@ -60,7 +60,7 @@ bind = SUPER, V, exec, cliphist list | wofi --dmenu | cliphist decode | wl-copy
 
 {{< tab >}}
 ```ini
-bind = SUPER, V, exec, cliphist list | fuzzel --dmenu | cliphist decode | wl-copy
+bind = $mainMod, V, exec, cliphist list | fuzzel --dmenu --with-nth 2 | cliphist decode | wl-copy
 ```
 {{< /tab >}}
 


### PR DESCRIPTION


before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ca3c8737-3bf9-4dc8-9f21-fbc9d05c6add" />

after
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5e610636-530f-484d-aedb-30b0fecf1b3e" />


