### PR TITLE
Useful Utilities/Clipboard-Managers: more user-friendly commands for `cliphist`

### DIFF
--- a/content/Useful Utilities/Clipboard-Managers.md
+++ b/content/Useful Utilities/Clipboard-Managers.md
@@ -45,7 +45,7 @@ you can edit it in `hyprland.conf`.
 
 {{< tab >}}
 ```ini
-bind = SUPER, V, exec, cliphist list | rofi -dmenu | cliphist decode | wl-copy
+bind = SUPER, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy
 ```
 {{< /tab >}}
 
@@ -57,7 +57,7 @@ bind = SUPER, V, exec, cliphist list | dmenu | cliphist decode | wl-copy
 
 {{< tab >}}
 ```ini
-bind = SUPER, V, exec, cliphist list | wofi --dmenu | cliphist decode | wl-copy
+bind = SUPER, V, exec, cliphist list | wofi --dmenu --pre-display-cmd "echo '%s' | cut -f 2" | cliphist decode | wl-copy
 ```
 {{< /tab >}}
 


### PR DESCRIPTION
As discussed in #1222, quick PR to use more user-friendly commands for `cliphist` by ignoring the first column i.e. ID used internally by `cliphist`.