### PR TITLE
Add info about workspace swipe gestures

### DIFF
--- a/content/Configuring/Gestures.md
+++ b/content/Configuring/Gestures.md
@@ -20,6 +20,7 @@ or scale the animation's speed by a float by adding `scale: [SCALE]`.
 Examples:
 
 ```ini
+gesture = 3, horizontal, workspace
 gesture = 3, down, mod: ALT, close
 gesture = 3, up, mod: SUPER, scale: 1.5, fullscreen
 gesture = 3, left, scale: 1.5, float

--- a/content/Configuring/Variables.md
+++ b/content/Configuring/Variables.md
@@ -347,6 +347,18 @@ _Subcategory `gestures:`_
 | workspace_swipe_use_r | if enabled, swiping will use the `r` prefix instead of the `m` prefix for finding workspaces. | bool | false |
 | close_max_timeout | the timeout for a window to close when using a 1:1 gesture, in ms | int | 1000 |
 
+{{< callout type=info >}}
+
+`workspace_swipe`, `workspace_swipe_fingers` and `workspace_swipe_min_fingers` were removed in favor of the new gestures system.
+
+You can add this gesture config to replicate the swiping functionality with 3 fingers. See the [gestures](../Gestures) page for more info.
+
+```ini
+gesture = 3, horizontal, workspace
+```
+
+{{< /callout >}}
+
 ### Group
 
 _Subcategory `group:`_


### PR DESCRIPTION
In the last [update](https://github.com/hyprwm/Hyprland/releases/tag/v0.51.0), three options essential for laptop/trackpad users were removed, rendering us unable to change workspaces using trackpad. I read the release notes here on GitHub to find out [why](https://github.com/hyprwm/Hyprland/pull/11490).

Still, the 1:1 replacement for workspace swipe gesture isn't on the gestures page. (`gesture = 3, horizontal, workspace`)

This PR adds that as an example, plus the removal info on the Variables page.

PS: thanks for the gestures, love them being 1:1