### PR TITLE
Broken link to Monitors page on /Useful-Utilities/Screen-Sharing

### DIFF
--- a/content/Useful Utilities/Screen-Sharing.md
+++ b/content/Useful Utilities/Screen-Sharing.md
@@ -13,7 +13,7 @@ installed, enabled and running if you don't have them yet.
 
 Ensure that the `bitdepth` set in your configuration 
 matches that of your physical monitor.
-See [Monitors](../Configuring/Monitors).
+See [Monitors](../../Configuring/Monitors).
 
 ## Screensharing
 


### PR DESCRIPTION
Currently link takes you to https://wiki.hypr.land/Useful-Utilities/Configuring/Monitors which doesn't exist, it should be https://wiki.hypr.land/Configuring/Monitors.