### PR TITLE
Update domain for version selector

### DIFF
--- a/layouts/partials/version.html
+++ b/layouts/partials/version.html
@@ -1,5 +1,5 @@
 {{- $version := .params.version | default "Latest git" -}}
-{{- $url := .url | default "https://wiki.hyprland.org/version-selector" -}}
+{{- $url := .url | default "https://wiki.hypr.land/version-selector" -}}
 
 {{- $outdated := "" -}}
 {{- if .params.outdated -}}


### PR DESCRIPTION
Openinig version selection leads to the old wiki domain that is blocked by cloudflare (in my case)
<img width="1341" height="882" alt="image" src="https://github.com/user-attachments/assets/f871da98-0843-4a9f-bc1f-bbcd15e7f5f6" />
