### PR TITLE
Fixed a typo in the wiki

### DIFF
--- a/content/Nvidia/_index.md
+++ b/content/Nvidia/_index.md
@@ -1,6 +1,6 @@
 ---
 weight: 8
-title: NVidia
+title: Nvidia
 ---
 
 ## Foreword


### PR DESCRIPTION
The wiki has Nvidia spelled with a capital V (NVidia) instead of the lowercase v (Nvidia)