### PR TITLE
content/Configuring/[Variables|Window-Rules]: Add size_limits_tiled config option

### DIFF
--- a/content/Configuring/Variables.md
+++ b/content/Configuring/Variables.md
@@ -459,6 +459,7 @@ _Subcategory `misc:`_
 | lockdead_screen_delay | delay after which the "lockdead" screen will appear in case a lockscreen app fails to cover all the outputs (5 seconds max) | int | 1000 |
 | enable_anr_dialog | whether to enable the ANR (app not responding) dialog when your apps hang | bool | true |
 | anr_missed_pings | number of missed pings before showing the ANR dialog | int | 5 |
+| size_limits_tiled | whether to apply minsize and maxsize rules to tiled windows | bool | false |
 
 ### Binds
 

--- a/content/Configuring/Window-Rules.md
+++ b/content/Configuring/Window-Rules.md
@@ -161,8 +161,8 @@ Dynamic rules are re-evaluated every time a property changes.
 | idleinhibit \[mode\] | Sets an idle inhibit rule for the window. If active, apps like `hypridle` will not fire. Modes: `none`, `always`, `focus`, `fullscreen`. |
 | opacity \[a\] | Additional opacity multiplier. Options for a: `float` -> sets an overall opacity, `float float` -> sets activeopacity and inactiveopacity respectively, `float float float` -> sets activeopacity, inactiveopacity and fullscreenopacity respectively. |
 | tag \[name\] | Applies the tag `name` to the window, use prefix `+`/`-` to set/unset flag, or no prefix to toggle the flag. |
-| maxsize \[w\] \[h\] | Sets the maximum size (x,y -> int). |
-| minsize \[w\] \[h\] | Sets the minimum size (x,y -> int).|
+| maxsize \[w\] \[h\] | Sets the maximum size (x,y -> int). Applies to floating windows. (use `misc:size_limits_tiled` to include tiled windows.) |
+| minsize \[w\] \[h\] | Sets the minimum size (x,y -> int). Applies to floating windows. (use `misc:size_limits_tiled` to include tiled windows.) |
 
 The following rules can also be set with [`setprop`](../Dispatchers#setprop):
 


### PR DESCRIPTION


<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
Config option for applying size limits to tiled windows. See https://github.com/hyprwm/Hyprland/pull/11898