### PR TITLE
dispatchers: Add relative link to details on workspace parameters

### DIFF
--- a/content/Configuring/Dispatchers.md
+++ b/content/Configuring/Dispatchers.md
@@ -11,7 +11,7 @@ layout pages (See the sidebar).
 | Param type | Description |
 | --- | --- |
 | window | a window. Any of the following: class regex (by default, optionally `class:`), `initialclass:` initial class regex, `title:` title regex, `initialtitle` initial title regex, `tag:` window tag regex, `pid:` the pid, `address:` the address, `activewindow` an active window, `floating` the first floating window on the current workspace, `tiled` the first tiled window on the current workspace |
-| workspace | see below. |
+| workspace | see [below]({{< relref "#workspaces" >}}). |
 | direction | `l` `r` `u` `d` left right up down |
 | monitor | One of: direction, ID, name, `current`, relative (e.g. `+1` or `-1`) |
 | resizeparams | relative pixel delta vec2 (e.g. `10 -10`), optionally a percentage of the window size (e.g. `20 25%`) or `exact` followed by an exact vec2 (e.g. `exact 1280 720`), optionally a percentage of the screen size (e.g. `exact 50% 50%`) |


### PR DESCRIPTION
Adds a relative link to the explanation of valid workspace parameters for dispatchers. 