### PR TITLE
Useful Utilities: Added Hyprlauncher to the App Launchers wiki

### DIFF
--- a/content/Useful Utilities/App-Launchers.md
+++ b/content/Useful Utilities/App-Launchers.md
@@ -3,6 +3,10 @@ weight: 6
 title: App launchers
 ---
 
+## Hyprlauncher
+Hyprlauncher is a first-party multipurpose and versatile launcher / picker for Hyprland.
+[GitHub](https://github.com/hyprwm/hyprlauncher)
+
 ## Wofi
 
 Wofi is a GTK-based customizable launcher for Wayland.


### PR DESCRIPTION
Added newly released Hyprlauncher. :D
I mean, why shouldn't it be here? Maybe it could be smart to say that it's in early development? idk

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
