### PR TITLE
Hyprpaper: Add warning about using correct hyprlang syntax when interacting via IPC

### DIFF
--- a/content/Hypr Ecosystem/hyprpaper.md
+++ b/content/Hypr Ecosystem/hyprpaper.md
@@ -217,8 +217,8 @@ If you start Hyprland with [uwsm](../../Useful-Utilities/Systemd-start), you can
 
 ## IPC
 
-hyprpaper supports IPC via `hyprctl`. Every dispatcher mentioned in
-[Configuration](#configuration) can be called with
+hyprpaper supports IPC via `hyprctl`. Every dispatcher mentioned in the
+[List of Dispatchers](#list-of-dispatchers) can be called with
 `hyprctl hyprpaper <dispatcher> <arg(s)>`.
 
 {{< callout type=info >}}


### PR DESCRIPTION
- Add warning about using correct hyprlang syntax when interacting via shell/IPC (related: https://github.com/hyprwm/hyprpaper/issues/282#issuecomment-3419910723)
- Add table with list of keywords, description and params, also serves as a quick summary of available commands and the args they accept.
- Make a subsection for each keyword for clarity
- Titlecase all headings
- Make warning about absolute paths into a warning callout
- Minor formatting
