### PR TITLE
Getting Started/Installation.md: void linux, change repository

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -273,16 +273,16 @@ Refer to the gist if anything fails.
 
 Hyprland is not available from Void Linux's official repositories
 due to the void developers being salty and personally disliking our main developer.
-However, a [third party repository](https://github.com/Makrennel/hyprland-void)
+However, a [third party repository](https://github.com/Encoded14/void-user-repository)
 is available with
-[binary packages](https://github.com/Makrennel/hyprland-void/tree/repository-x86_64-glibc)
+[binary packages](https://github.com/Encoded14/void-user-repository/releases)
 built in CI by GitHub Actions.
 
 You can add this repository by creating a file such as
-`/etc/xbps.d/hyprland-void.conf` with the following contents:
+`/etc/xbps.d/20-void-user-repository.conf` with the following contents:
 
-```plain {filename="/etc/xbps.d/hyprland-void.conf"}
-repository=https://raw.githubusercontent.com/Makrennel/hyprland-void/repository-x86_64-glibc
+```plain {filename="/etc/xbps.d/20-void-user-repository.conf"}
+repository=https://github.com/Encoded14/void-user-repository/releases/latest/download
 ```
 
 Then you can install the packages as you would any other:
@@ -296,9 +296,9 @@ xbps-query -Rs hypr # This will require you to have already accepted the reposit
 ```
 
 More information is available in the
-[hyprland-void README](https://github.com/Makrennel/hyprland-void/blob/master/README.md),
+[void-user-repository README](https://github.com/Encoded14/void-user-repository/blob/master/README.md),
 including information about how you can
-[manually build](https://github.com/Makrennel/hyprland-void?tab=readme-ov-file#manually-building)
+[manually build](https://github.com/Encoded14/void-user-repository?tab=readme-ov-file#manually-building)
 Hyprland for Void Linux using the templates provided.
 
 {{% /details %}}


### PR DESCRIPTION
The maintainer of the [current repository](https://github.com/Makrennel/hyprland-void) has been inactive on Github since April and the packages are stuck at hyprland v0.49. I have made a [repository](https://github.com/Encoded14/void-user-repository) containing the (mostly) same templates but updated to the newest version. 