### PR TITLE
Hypr Ecosystem/hyprsunset: fix typo

### DIFF
--- a/content/Hypr Ecosystem/hyprsunset.md
+++ b/content/Hypr Ecosystem/hyprsunset.md
@@ -29,7 +29,7 @@ Configuration is done via the config file at `~/.config/hypr/hyprsunset.conf` Th
 
 Hyprsunset uses profiles to determine when to change temperature and gamma. You can define as many profiles as you like. Each Profile is activated at it's specified time and resets all options set by other profiles.
 
-On startup, hyprsunset will apply the current profile. For example, when launching hyprsunset with the following example config at 20:00, it will activate the first profile, essentially changing nothing. Once the clock strucks 21:00, hyprsunset will automatically apply the new profile.
+On startup, hyprsunset will apply the current profile. For example, when launching hyprsunset with the following example config at 20:00, it will activate the first profile, essentially changing nothing. Once the clock strikes 21:00, hyprsunset will automatically apply the new profile.
 
 **Example Configuration**
 ```ini


### PR DESCRIPTION
"clock strucks" -> "clock strikes"