### PR TITLE
Update Debian install instructions, not in Trixie

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -143,13 +143,11 @@ Debian's Hyprland is **extremely** outdated. I do not recommend using the packag
 
 {{< /callout >}}
 
-Hyprland recently made it into the SID and trixie repos and can be installed with
+Hyprland recently made it into the SID repository and can be installed with
 
 ```sh
 sudo apt install hyprland
 ```
-
-Note: Even though Hyprland is in the trixie repos, it is still recommended to install from SID, as some dependencies in the trixie repo are outdated.
 
 Alternatively, you can also follow the instructions under
 ["Manual (Manual Build)"](#manual-manual-build) to build Hyprland yourself.


### PR DESCRIPTION
Hyprland was removed from Debian Trixie and Debian Testing due to the
maintainter's request:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1107152

It is only available in Unstable and sadly not up-to-date, since it
can't migrate to Testing and Stable as per the request made.