### PR TITLE
fix: replace gesture with action due to misuse and refactor tables in Gestures.md

### DIFF
--- a/content/Configuring/Gestures.md
+++ b/content/Configuring/Gestures.md
@@ -29,26 +29,30 @@ gesture = 3, left, scale: 1.5, float
 ### Directions
 
 The following directions are supported:
-- `swipe` -> any swipe
-- `horizontal` -> horizontal swipe
-- `vertical` -> vertical swipe
-- `left`, `right`, `up`, `down` -> swipe directions
-- `pinch` -> any pinch
-- `pinchin`, `pinchout` -> directional pinch 
+| `direction` | Description |
+| -- | -- |
+| `swipe` | any swipe
+| `horizontal` | horizontal swipe
+| `vertical` | vertical swipe
+| `left`, `right`, `up`, `down` | swipe directions
+| `pinch` | any pinch
+| `pinchin`, `pinchout` | directional pinch 
 
-## Available gestures
 
-Specifying `unset` as the gesture will unset a specific gesture that was previously set. Please note it needs to exactly match everything
+
+### Actions
+
+Specifying `unset` as the action will unset a specific gesture that was previously set. Please note it needs to exactly match everything
 from the original gesture including direction, mods, fingers and scale.
 
-| gesture | description | arguments |
+| `action` | Description | Arguments |
 | -- | -- | -- |
-| dispatcher | the most basic, executes a dispatcher once the gesture ends | `dispatcher, params` |
-| workspace | workspace swipe gesture, for switching workspaces |
-| move | moves the active window | none |
-| resize | resizes the active window | none |
-| special | toggles a special workspace | special workspace without the `special:`, e.g. `mySpecialWorkspace` |
-| close | closes the active window | none |
-| fullscreen | fullscreens the active window | none for fullscreen, `maximize` for maximize |
-| float | floats the active window | none for toggle, `float` or `tile` for one-way | 
+| `dispatcher` | the most basic, executes a dispatcher once the gesture ends | `dispatcher, params` |
+| `workspace` | workspace swipe gesture, for switching workspaces |
+| `move` | moves the active window | none |
+| `resize` | resizes the active window | none |
+| `special` | toggles a special workspace | special workspace without the `special:`, e.g. `mySpecialWorkspace` |
+| `close` | closes the active window | none |
+| `fullscreen` | fullscreens the active window | none for fullscreen, `maximize` for maximize |
+| `float` | floats the active window | none for toggle, `float` or `tile` for one-way | 
 


### PR DESCRIPTION
mistakenly the word gestures is used instead of  `action` in available actions part

also the new tables would be more user-friendly and easier to understand for readers
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
