### PR TITLE
Backend: Fix Hugo warning about deprecation of `markup.goldmark.renderHooks.link.enableDefault`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ path = "github.com/imfing/hextra"
 unsafe = true
 
 [markup.goldmark.renderHooks.link]
-enableDefault = true
+useEmbedded = "fallback"
 
 [markup.highlight]
 noClasses = false


### PR DESCRIPTION
From the Hugo docs: https://gohugo.io/configuration/markup/#renderhookslinkenabledefault