### PR TITLE
Hypr Ecosystem/hyprlock: Correct default border size to 4

### DIFF
--- a/content/Hypr Ecosystem/hyprlock.md
+++ b/content/Hypr Ecosystem/hyprlock.md
@@ -254,7 +254,7 @@ If `path` is empty or missing, nothing will be shown.
 | path | image path | str | [[Empty]] |
 | size | size scale based on the lesser side of the image | int | 150 |
 | rounding | negative values result in a circle | int | -1 |
-| border_size | border size | int | 0 |
+| border_size | border size | int | 4 |
 | border_color | border color | gradient | rgba(221, 221, 221, 1.0) |
 | rotate | rotation in degrees, counter-clockwise | int | 0 |
 | reload_time | seconds between reloading, 0 to reload with SIGUSR2 | int | -1 |


### PR DESCRIPTION
The correct default `border_size` for `image` is 4 as seen here: https://github.com/hyprwm/hyprlock/blob/98b86752fe4867bd14ef96a92ea788229af93130/src/config/ConfigManager.cpp#L269