### PR TITLE
Fix Polish translation for anime girls count

### DIFF
--- a/content/Contributing and Debugging/Translations.md
+++ b/content/Contributing and Debugging/Translations.md
@@ -41,6 +41,10 @@ registerEntry("pl_PL", TXT_KEY_HELLO, [](const Hyprutils::I18n::translationVarMa
     int peopleAmount = std::stoi(vars.at("count"));
     if (peopleAmount == 1)
         return "Mam {count} dziewczynkę anime.";
+    int last = peopleAmount % 10;
+    int lastTwo = peopleAmount % 100;
+    if (last >= 2 && last <= 4 && !(lastTwo >= 12 && lastTwo <= 14))
+        return "Mam {count} dziewczynki anime.";
     return "Mam {count} dziewczynek anime.";
 });
 ```


### PR DESCRIPTION
Original code only handled singular vs plural, failing for counts 2-4 and numbers ending in 2-4 except for teens (12-14). Updated logic correctly handles all positive numbers, including exceptions, ensuring proper grammar: "dziewczynkę", "dziewczynki", or "dziewczynek".

For example `peopleAmount` of `2`, `3`, `4` or `23` should return `Mam 23 dziewczynki anime.` same with e.g. `534` but not if it ends with a teen number like `14` with e.g. `414` the proper form is `Mam 414 dziewczynek anime.`.