### PR TITLE
Crashes and Bugs: open an issue -> open a discussion

### DIFF
--- a/content/Crashes and Bugs/_index.md
+++ b/content/Crashes and Bugs/_index.md
@@ -73,8 +73,8 @@ Try to reproduce your issue as fast as possible so we don't have to sift through
 
 First of all, **_READ THE [FAQ PAGE](../FAQ)_**
 
-If your bug is not listed there, you can ask on the Discord server or open an
-issue on GitHub.
+If your bug is not listed there, you can ask on the Discord server or open a
+[discussion on GitHub](https://github.com/hyprwm/Hyprland/discussions).
 
 ## Bisecting an issue
 


### PR DESCRIPTION
It is now encouraged to open a discussion rather than an issue.
This updates the wiki to recommend a discussion.