### PR TITLE
Rename swww to awww and update link

### DIFF
--- a/content/Useful Utilities/Wallpapers.md
+++ b/content/Useful Utilities/Wallpapers.md
@@ -25,11 +25,11 @@ and other fancy stuff. [GitHub](https://github.com/danyspin97/wpaperd).
 A neat mpv wrapper to play a video as your wallpaper.
 [GitHub](https://github.com/GhostNaN/mpvpaper).
 
-## swww
+## awww
 
 An efficient animated wallpaper daemon for Wayland, controlled at runtime, which
 means you can change wallpapers without even needing to restart.
-[GitHub](https://github.com/Horus645/swww)
+[Codeberg](https://codeberg.org/LGFae/awww)
 
 ## waypaper
 


### PR DESCRIPTION
swww was renamed to awww and moved development to codeberg.

More details in maintainer's blog post https://www.lgfae.com/posts/2025-10-29-RenamingSwww.html
