### PR TITLE
Useful Utilieies/Wallpapers: Rename `swww` to `awww`.

### DIFF
--- a/content/Useful Utilities/Wallpapers.md
+++ b/content/Useful Utilities/Wallpapers.md
@@ -25,11 +25,11 @@ and other fancy stuff. [GitHub](https://github.com/danyspin97/wpaperd).
 A neat mpv wrapper to play a video as your wallpaper.
 [GitHub](https://github.com/GhostNaN/mpvpaper).
 
-## swww
+## awww
 
 An efficient animated wallpaper daemon for Wayland, controlled at runtime, which
 means you can change wallpapers without even needing to restart.
-[GitHub](https://github.com/Horus645/swww)
+[Codeberg](https://codeberg.org/LGFae/awww)
 
 ## waypaper
 


### PR DESCRIPTION
`swww` was renamed to `awww` and development moved to Codeberg.

Reason for the move is available at maintainer's blog: https://www.lgfae.com/posts/2025-10-29-RenamingSwww.html


