### PR TITLE
Remove Fedora from list of rolling release distrobutions

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -20,8 +20,8 @@ title: Installation
 
 We officially run and test Hyprland on Arch and NixOS, and we guarantee Hyprland will work there. For any other distro
 (not based on Arch/Nix) you might have varying amounts of success. However,
-since Hyprland is extremely bleeding-edge, distros like Pop!\_OS, Ubuntu, etc.
-will have **major** issues running Hyprland. Rolling release distros like Fedora, openSUSE, etc. will likely be fine.
+since Hyprland is extremely bleeding-edge, point release distros like Pop!\_OS, Fedora, Ubuntu, etc.
+will have **major** issues running Hyprland. Rolling release distros like openSUSE, Solus ,etc. will likely be fine.
 
 ## Installation
 


### PR DESCRIPTION
I have removed Fedora from the list of rolling release distros and replaced it with Solus. Fedora is not a rolling release distro and as such will likely have issues with Hyprland more comparable to Ubuntu or Pop!OS

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
