### PR TITLE
Configuring/Uncommon-tips-&-tricks: Improved User-Experience of "Alt tab behaviour"

### DIFF
--- a/content/Configuring/Uncommon-tips-&-tricks.md
+++ b/content/Configuring/Uncommon-tips-&-tricks.md
@@ -338,7 +338,7 @@ address=$(hyprctl -j clients | jq -r 'sort_by(.focusHistoryID) | .[] | select(.w
 	      awk -F"\t" '{print $1}')
 
 if [ -n "$address" ] ; then
-	echo "$address" > /tmp/alttab/address
+	echo "$address" > $XDG_RUNTIME_DIR/hypr/alttab/address
 fi
 
 hyprctl -q dispatch submap reset
@@ -355,8 +355,8 @@ line="$1"
 IFS=$'\t' read -r addr _ <<< "$line"
 dim=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}
 
-grim -t png -l 0 -w "$addr" /tmp/alttab/preview.png
-chafa --animate false --dither=none -s "$dim" "/tmp/alttab/preview.png"
+grim -t png -l 0 -w "$addr" $XDG_RUNTIME_DIR/hypr/alttab/preview.png
+chafa --animate false --dither=none -s "$dim" "$XDG_RUNTIME_DIR/hypr/alttab/preview.png"
 ```
 
 4. create file `touch $XDG_CONFIG_HOME/hypr/scripts/alttab/disable.sh && chmod +x $XDG_CONFIG_HOME/hypr/scripts/alttab/disable.sh` and add:
@@ -371,10 +371,10 @@ hyprctl -q --batch "keyword unbind ALT, TAB ; keyword unbind ALT SHIFT, TAB ; ke
 5. create file `touch $XDG_CONFIG_HOME/hypr/scripts/alttab/enable.sh && chmod +x $XDG_CONFIG_HOME/hypr/scripts/alttab/enable.sh` and add:
 ```bash {filename="enable.sh"}
 #!/usr/bin/env bash
-mkdir -p /tmp/alttab
+mkdir -p $XDG_RUNTIME_DIR/hypr/alttab
 hyprctl -q --batch "keyword animations:enabled false; keyword unbind ALT, TAB ; keyword unbind ALT SHIFT, TAB"
 footclient -a alttab $HOME/.config/hypr/scripts/alttab/alttab.sh $1
-hyprctl --batch -q "dispatch focuswindow address:$(cat /tmp/alttab/address) ; dispatch alterzorder top"
+hyprctl --batch -q "dispatch focuswindow address:$(cat $XDG_RUNTIME_DIR/hypr/alttab/address) ; dispatch alterzorder top"
 ```
 
 ## Config versioning


### PR DESCRIPTION
The previous implementation executed the `focuswindow` and `alterzorder` dispatchers before the footclient process terminated. This created a timing issue that is particularly noticable during window focusing across workspaces.

For example: A user on workspace 2 uses the alt-tab command to focus one out of several windows on workspace 1 which was not previously focused when the user was working on workspace 1. The focus is correctly updated but Hyprland fails to draw the active border around the newly focused window.

This is fixed by updating the focus after the footclient has terminated.

Detailed changes:
- make the scripts work with resources in a /tmp directory (this is cleaner in oppose the previous approach, especially on NixOS where the directory might be write protected)
- decoupled the focus window logic
- made `alttab.sh` handle the submap bindings
- removed noise from `chafa` parsed images
- explicitely sourced the `foot.ini` to the server command or else the `footclient` won't have user defined styles and defaults to foot's out of the box style

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
