### PR TITLE
utilities: add link to hyprlauncher

### DIFF
--- a/content/Useful Utilities/App-Launchers.md
+++ b/content/Useful Utilities/App-Launchers.md
@@ -5,7 +5,7 @@ title: App launchers
 
 ## Hyprlauncher
 Hyprlauncher is a first-party multipurpose and versatile launcher / picker for Hyprland.
-[GitHub](https://github.com/hyprwm/hyprlauncher)
+See its usage and config [here](../../Hypr-Ecosystem/hyprlauncher).
 
 ## Wofi
 


### PR DESCRIPTION
Added a link to the hyprlauncher page in the app launchers, which I believe is missing 
https://wiki.hypr.land/Useful-Utilities/App-Launchers/