### PR TITLE
Permissions: renamed hyprland-qtutils to hyprland-guiutils

### DIFF
--- a/content/Configuring/Permissions.md
+++ b/content/Configuring/Permissions.md
@@ -3,7 +3,7 @@ weight: 14
 title: Permissions
 ---
 
-If you have `hyprland-qtutils` installed, you can make use of Hyprland's built-in
+If you have `hyprland-guiutils` installed, you can make use of Hyprland's built-in
 permission system.
 
 For now, it only has a few permissions, but it might include more in the future.


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
hyprland-qtutils was replaced by hyprland-guiutils, so it has to say to install hyprland-guiutils instead. Also, in Arch hypryou-guiutils is dependency so *maybe* it could be better to even remove the line cause this package is now always installed. 