### PR TITLE
Getting Started/installation: Add hyprwire-git package to Arch dependencies installation command

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -350,7 +350,7 @@ Dependencies:
 {{% details title="Arch" closed="true" %}}
 
 ```plain
-yay -S ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite libxrender libxcursor pixman wayland-protocols cairo pango libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang-git hyprcursor-git hyprwayland-scanner-git xcb-util-errors hyprutils-git glaze hyprgraphics-git aquamarine-git re2 hyprland-qtutils-git muparser
+yay -S ninja gcc cmake meson libxcb xcb-proto xcb-util xcb-util-keysyms libxfixes libx11 libxcomposite libxrender libxcursor pixman wayland-protocols cairo pango libxkbcommon xcb-util-wm xorg-xwayland libinput libliftoff libdisplay-info cpio tomlplusplus hyprlang-git hyprcursor-git hyprwayland-scanner-git hyprwire-git xcb-util-errors hyprutils-git glaze hyprgraphics-git aquamarine-git re2 hyprland-qtutils-git muparser
 ```
 
 _(Please make a pull request or open an issue if any packages are missing from


### PR DESCRIPTION
While trying to install hyprland in my new machine, I got this error in the cmake build command:

```sh
make all && sudo make install

....

--   Package 'hyprwire' not found
CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:1093 (message):
  The following required packages were not found:

   - hyprwire

Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:1166 (_pkg_check_modules_internal)
  hyprctl/CMakeLists.txt:8 (pkg_check_modules)
```
Looking for the depenencies installation command for Arch, the hyprwire package is not in the list.

So I did this PR adding it:

<img width="1085" height="406" alt="image" src="https://github.com/user-attachments/assets/45251546-3a26-4775-8621-0ba38e122bc1" />
