### PR TITLE
Add section on gesture flags

### DIFF
--- a/content/Configuring/Gestures.md
+++ b/content/Configuring/Gestures.md
@@ -56,3 +56,17 @@ from the original gesture including direction, mods, fingers and scale.
 | `fullscreen` | fullscreens the active window | none for fullscreen, `maximize` for maximize |
 | `float` | floats the active window | none for toggle, `float` or `tile` for one-way | 
 
+
+### Flags
+
+Gestures support flags though the syntax:
+
+```ini
+gesture[flags] = ...
+```
+
+Supported flags:
+
+| Flag | Name | Description |
+| -- | -- | -- |
+| `p` | bypass | Allows the gesture to bypass shortcut inhibitors. |


### PR DESCRIPTION
Wiki mr for hyprwm/Hyprland#12692

Adds section to Configuring/Gesture for basic flag syntax and list of supported flags.
