### PR TITLE
Hypr-Ecosystem/hyprpaper: Add example with fallback background

### DIFF
--- a/content/Hypr Ecosystem/hyprpaper.md
+++ b/content/Hypr Ecosystem/hyprpaper.md
@@ -59,6 +59,12 @@ wallpaper {
     fit_mode = cover
 }
 
+wallpaper {
+    monitor = 
+    path = ~/fallback.jxl
+    fit_mode = cover
+}
+
 # ...
 ```
 


### PR DESCRIPTION
Adds an example with an empty monitor in a wallpaper block to strongly indicate that `monitor` parameter must be clearly defined as empty, and omitting it doesn't make it empty.
