### PR TITLE
Minor clarifications for installing on Arch.

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -51,7 +51,12 @@ Install a tagged release from the arch packages:
 sudo pacman -S hyprland
 ```
 
-or install from the AUR, which compiles the latest source:
+##### Compile from source automatically
+
+> [!WARNING]
+> Read the warning about using `-git` packages or compiling from source under [Installation](#installation) first!
+
+Install from the AUR, which compiles the latest source:
 
 ```shell
 yay -S hyprland-git


### PR DESCRIPTION
Probably would've saved dumb past me from missing the warning advising against using the `-git` packages or building from source for reliability. :P