### PR TITLE
Remove unmaintained preconfigured Hyprland-Dots entry

### DIFF
--- a/content/Getting Started/Preconfigured-setups.md
+++ b/content/Getting Started/Preconfigured-setups.md
@@ -22,20 +22,6 @@ It includes simple gui settings apps, pre-configured feature-rich panels, a welc
 
 ![Image of ML4W dotfiles](https://i.ibb.co/7rxTRrw/395854121-47ed1ae0-a660-46f3-9bf5-917da0d3f675.png)
 
-## JaKooLit
-
-Another great option is installing JaKooLit's dotfiles. They are another feature-rich and very well
-maintained option.
-
-JaKooLit provides installation scripts for many distros for their dotfiles, with
-many themes to choose from.
-
-[GitHub](https://github.com/JaKooLit/Hyprland-Dots)
-
-[Youtube](https://www.youtube.com/@Ja.KooLit)
-
-![Image of JaKooLit's dotfiles](https://i.ibb.co/7tMsnTv/default-waybar.png)
-
 ## end_4
 
 Like material styling? Want a lot of great apps? Don't mind a tiny bit of tinkering? end-4 has you covered.


### PR DESCRIPTION
This setup (JaKooLit's Hyprland-Dots) is no longer actively maintained and currently has no maintainers.
Removing it avoids confusion for new users.