### PR TITLE
Configuring/Variables: change xkb layout list file

### DIFF
--- a/content/Configuring/Variables.md
+++ b/content/Configuring/Variables.md
@@ -204,7 +204,7 @@ _Subcategory `decoration:shadow:`_
 > [!NOTE] **XKB Settings**
 >
 > You can find a list of models, layouts, variants and options in
-> [`/usr/share/X11/xkb/rules/base.lst`](file:///usr/share/X11/xkb/rules/base.lst).
+> [`/usr/share/X11/xkb/rules/evdev.lst`](file:///usr/share/X11/xkb/rules/evdev.lst).
 > Alternatively, you can use the `localectl` command to discover what is available
 > on your system.
 > 


### PR DESCRIPTION
In the instruction to list available XKB keyboard layouts,  change base.lst to evdev.lst. The files are usually identical but they can differ if the user has created custom keyboard layouts.

The evdev files are the correct ones to look at anyway since evdev rules are used on linux-systems (https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Config.html). 