### PR TITLE
IPC: add note about socket behaviour

### DIFF
--- a/content/IPC/_index.md
+++ b/content/IPC/_index.md
@@ -19,6 +19,12 @@ Used for hyprctl-like requests. See the
 
 basically, write `[flag(s)]/command args`.
 
+> [!NOTE]
+> Hyprland evaluates connections to this socket completely synchronously,
+> which means that any unclosed connections *will cause Hyprland to freeze*
+> until the five-second timeout is reached. Ensure that you always open the socket
+> immediately before writing requests and close it afterward.
+
 ## `$XDG_RUNTIME_DIR/hypr/[HIS]/.socket2.sock`
 
 Used for events. Hyprland will write to each connected client live events like


### PR DESCRIPTION
When connecting to Hyprland's IPC socket for writing hyprctl requests (`$XDG_RUNTIME_DIR/hypr/[HIS]/.socket.sock`), Hyprland will pause all other tasks including rendering until the connection is closed. This is not necessarily a problem, and is apparently intended behaviour, see [Hyprland #8919](https://github.com/hyprwm/Hyprland/issues/8919).

However, if the socket is open for an unusually long time, such as if a connection is not properly closed, or one is created but no data is written, Hyprland will freeze completely until hitting a five-second timeout. This is as far as I can tell completely undocumented, and I recently spent an hour of my life figuring out this is what was happening with a script I was working on.

I feel a brief note about this quirk on the wiki may spare someone else in the future this headache. As an aside, I think this entire section could do with expansion, considering Hyprland's IPC is in my opinion one of its strengths versus other compositors.