### PR TITLE
Hypr-Ecosystem/hyprlock: add locked bind flag hint to keybinds section

### DIFF
--- a/content/Hypr Ecosystem/hyprlock.md
+++ b/content/Hypr Ecosystem/hyprlock.md
@@ -123,6 +123,8 @@ The following keys and key-combinations describe hyprlock's default behaviour:
 | `Ctrl + u` | Clear password buffer |
 | `Ctrl + Backspace` | Clear password buffer |
 
+The [bind flag](../../Configuring/Binds/#bind-flags) `l` can be used to allow specific hyprland keybinds to also work while hyprlock is active (e.g. brightness/volume/media control).
+
 ## Widgets
 
 The entire configuration of how hyprlock looks is done via widgets.


### PR DESCRIPTION
Adds a note to the hyprlock page, promoting the use of the bind flag `l` (locked) on specific hyprland keybinds to allow those keybinds on the lock screen.

While the bind flags are well-documented on the binds flag already, I think it's helpful to reference this on the hyprlock page as well. (This issue hyprwm/hyprlock#479 seems to confirm that it's not the most obvious feature)