### PR TITLE
Useful Utilities/Other: add hyprKCS

### DIFF
--- a/content/Useful Utilities/Other.md
+++ b/content/Useful Utilities/Other.md
@@ -21,6 +21,11 @@ Hyprland.
 
 [HyprLS](https://github.com/hyprland-community/hyprls) by _gwennlbh_: A LSP server to provide auto-completion and more for Hyprland's configuration files in neovim, VS Code & others
 
+### Keybind Management
+
+[hyprKCS](https://github.com/kosa12/hyprKCS) by _kosa12_: A fast, minimal
+Hyprland keybind manager written in Rust/GTK4.
+
 ### IPC wrappers
 
 [hyprland-rs](https://github.com/yavko/hyprland-rs) by _yavko_: A neat wrapper


### PR DESCRIPTION
Added [hyprKCS](https://github.com/kosa12/hyprKCS) to the Other utilities page under a new Keybind Management section.
