### PR TITLE
Contributing and Debugging/PR-Guidelines: Fix clang-format instruction for default bash config

### DIFF
--- a/content/Contributing and Debugging/PR-Guidelines.md
+++ b/content/Contributing and Debugging/PR-Guidelines.md
@@ -15,7 +15,7 @@ the time for the maintainers.
 
 ### Before you submit
 
-Make sure you ran clang-format: `clang-format -i src/**/*{cpp,hpp}`
+Make sure you ran clang-format: `clang-format -i src/*{cpp,hpp} src/**/*{cpp,hpp}`
 
 Check if your changes don't violate `clang-tidy`. Usually this is built into your IDE.
 


### PR DESCRIPTION
Default bash config has `globstar` disabled, so the command does not format files directly in `src/`.
