### PR TITLE
Contributing and Debugging/PR Guidelines: Use find instead of globstar for clang-format command

### DIFF
--- a/content/Contributing and Debugging/PR-Guidelines.md
+++ b/content/Contributing and Debugging/PR-Guidelines.md
@@ -15,7 +15,7 @@ the time for the maintainers.
 
 ### Before you submit
 
-Make sure you ran clang-format: `clang-format -i src/*{cpp,hpp} src/**/*{cpp,hpp}`
+Make sure you ran clang-format: `clang-format -i $(find src -type f \( -name "*.cpp" -o -name "*.hpp" \))`
 
 Check if your changes don't violate `clang-tidy`. Usually this is built into your IDE.
 


### PR DESCRIPTION
My last PR didn't actually fix the issue, my bad. That's what I get for testing by eyeballing a wall of text.

Works in bash, sh, zsh and fish (after version 3.4.0 from March 2022).

```bash
$ shopt globstar
globstar off

$ ls src/**/*{cpp,hpp} | wc -l
263

$ ls src/*{cpp,hpp} src/**/*{cpp,hpp} | wc -l
270

$ ls $(find src -type f \( -name "*.cpp" -o -name "*.hpp" \)) | wc -l
462

$ shopt -s globstar && shopt globstar
globstar on

$ ls src/**/*{cpp,hpp} | wc -l
462

$ ls $(find src -type f \( -name "*.cpp" -o -name "*.hpp" \)) | wc -l
462
```