### PR TITLE
Useful Utilities/Clipboard Managers: add cursor-clip

### DIFF
--- a/content/Useful Utilities/Clipboard-Managers.md
+++ b/content/Useful Utilities/Clipboard-Managers.md
@@ -24,6 +24,7 @@ Alternative to `cliphist` with a couple extra features (e.g. max age for entries
 - [`wl-clip-persist`](https://github.com/Linus789/wl-clip-persist) - When copying something on Wayland, the copied data remains in the clipboard until the application that was copied from is closed; after that, the data disappears and can no longer be pasted.  
 To fix this problem, you can use `wl-clip-persist` which will preserve the data in the clipboard after the application is closed.
 
+- [`cursor-clip`](https://github.com/Sirulex/cursor-clip) - A modern wayland clipboard manager built with Rust, GTK4, Libadwaita and Layer Shell that makes clipboard handling more reliable. Features a Windows 11–style clipboard history interface with native GNOME design, which is always positioned at the current mouse pointer location. Supports all clipboard formats, including text, images, and files. 
 ## cliphist
 
 Start by adding the following lines to your `~/.config/hypr/hyprland.conf`
@@ -225,3 +226,23 @@ Can also be applied to the primary selection (i.e. middle click to paste selecti
 ```ini
 exec-once = wl-clip-persist --clipboard primary
 ```
+
+## cursor-clip
+
+Start by adding the following line to your `~/.config/hypr/hyprland.conf`
+
+```ini
+exec-once = cursor-clip --daemon
+```
+
+This starts the background daemon that monitors clipboard changes.
+
+To bind `cursor-clip` to a hotkey for quick access, you can add the following keybind to your `hyprland.conf`:
+
+```ini
+bind = SUPER, V, exec, cursor-clip
+```
+
+When triggered, `cursor-clip` will automatically position its overlay window at your current mouse location, providing a Windows 11-style clipboard history interface. The overlay supports all clipboard formats including text, images, and files, with a native GNOME design built using GTK4 and Libadwaita.
+
+For further information, please refer to the program's GitHub repository linked at the top of the page.


### PR DESCRIPTION


docs: add cursor-clip clipboard manager documentation

- Added new section for cursor-clip clipboard manager in Useful Utilities/Clipboard-Managers.md
- Included setup instructions for background daemon (cursor-clip --daemon)
- Added keybind example for overlay launch (Super+V)
- Documented key features: Windows 11-style interface, mouse position tracking, GTK4/Libadwaita design