### PR TITLE
Hypr-Ecosystem/hyprshutdown: add CLI options, no-fork, and NVIDIA+SDDM flags

### DIFF
--- a/content/Hypr Ecosystem/hyprshutdown.md
+++ b/content/Hypr Ecosystem/hyprshutdown.md
@@ -7,6 +7,19 @@ title: hyprshutdown
 a GUI and gracefully asks apps to exit, then quits Hyprland. It's the recommended way to exit hyprland,
 as otherwise (e.g. `dispatch exit`) apps will die instead of exiting.
 
+## Command-Line Options
+
+| Option | Description |
+|--------|-------------|
+| `--vt N` | Switch to VT N after exit (fixes NVIDIA+SDDM black screen) |
+| `--dry-run` | Show UI without actually closing apps or exiting |
+| `--no-exit` | Close apps but don't exit Hyprland |
+| `--top-label`, `-t` | Custom text for the shutdown dialog |
+| `--post-cmd`, `-p` | Command to run after Hyprland exits |
+| `--no-fork` | Run in foreground (don't daemonize) |
+| `--verbose` | Enable debug logging |
+| `--help`, `-h` | Show help |
+
 ## Tips and tricks
 
 If you want to shut the system down, or reboot, instead of logging out, you can do things like this:
@@ -16,3 +29,24 @@ hyprshutdown -t 'Shutting down...' --post-cmd 'shutdown -P 0'
 
 hyprshutdown -t 'Restarting...' --post-cmd 'reboot'
 ```
+
+## Troubleshooting
+
+### NVIDIA + SDDM Users
+
+If you experience a black screen / hang when logging out with NVIDIA GPU and SDDM display manager, use the `--vt` flag:
+
+```bash
+hyprshutdown --vt 2
+```
+
+**Why this is needed:** On NVIDIA systems with SDDM, the display doesn't automatically switch back to SDDM's virtual terminal (typically VT2) when Hyprland exits. The `--vt` flag forces a VT switch after logout.
+
+**Setup:** The VT switch requires passwordless sudo for `chvt`:
+
+```bash
+echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/chvt" | sudo tee /etc/sudoers.d/chvt
+sudo chmod 440 /etc/sudoers.d/chvt
+```
+
+This is safe because `chvt` only switches virtual terminals and cannot be exploited for privilege escalation.


### PR DESCRIPTION

- Add command-line options reference table, with brief descriptions

- Add troubleshooting section for NVIDIA+SDDM black screen issue with --vt flag workaround

## Reason
- needed for recently merged [PR 16](https://github.com/hyprwm/hyprshutdown/pull/16)
- Table give descriptions and use case for `--vt N` flag
- includes previously existing flags and two new `--no-fork` and `--vt N`


<img width="721" height="479" alt="image" src="https://github.com/user-attachments/assets/d5231768-8261-4d76-a1a9-013555154b69" />

<img width="735" height="648" alt="image" src="https://github.com/user-attachments/assets/636333af-f4a0-4c3e-93e8-3219c4b994ff" />

