### PR TITLE
treewide: add head-end partial with SEO keywords

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -77,6 +77,7 @@ icon = "github"
 description        = "The documentation for Hyprland."
 displayUpdatedDate = true
 dateFormat         = "January 2, 2006"
+keywords           = ["hyprland", "wiki", "hypr", "land"]
 
 [params.navbar]
 displayTitle = true

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,9 +1,8 @@
 ---
 cascade:
   type: docs
+title: Hyprland Wiki
 ---
-
-# Hyprland Wiki
 
 Hello there, dear traveler! Welcome to the Hyprland Wiki!
 

--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,0 +1,10 @@
+{{- if .Params.keywords -}}
+  {{/* Use keywords defined in the page front matter */}}
+  <meta name="keywords" content="{{ delimit .Params.keywords ", " }}">
+{{- else if .Params.tags -}}
+  {{/* Fallback to tags if no keywords are defined */}}
+  <meta name="keywords" content="{{ delimit .Params.tags ", " }}">
+{{- else if .Site.Params.keywords -}}
+  {{/* Global fallback from hugo.yaml */}}
+  <meta name="keywords" content="{{ delimit .Site.Params.keywords ", " }}">
+{{- end -}}


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->

Fixes https://github.com/hyprwm/Hyprland/discussions/12329

Adds keywords to each page's `head`.

Unsure whether to use `meta name` vs `meta itemprop`. Hextra seems to use `meta itemprop` for pages that include `keywords` in their frontmatter.
