### PR TITLE
Useful-Utilities/Clipboard-Managers/: Update to new rules format

### DIFF
--- a/content/Useful Utilities/Clipboard-Managers.md
+++ b/content/Useful Utilities/Clipboard-Managers.md
@@ -184,9 +184,7 @@ exec-once = clipse -listen
 You can bind the TUI to a something nice like this:
 
 ```ini
-windowrule = match:class clipse, float
-windowrule = match:class clipse, size 622 652
-windowrule = match:class clipse, stay_focused
+windowrule = float on, size 622 652, stay_focused on, match:class ^(clipse)$
 
 bind = SUPER, V, exec, kitty --class clipse -e clipse
 ```


### PR DESCRIPTION
The syntax of the window rules was updated to the new format so it works in current config files. The section changed is the one related to clipse

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
