### PR TITLE
Nvidia: add warning that early KMS may break hibernation

### DIFF
--- a/content/Nvidia/_index.md
+++ b/content/Nvidia/_index.md
@@ -97,6 +97,10 @@ MODULES=(... nvidia nvidia_modeset nvidia_uvm nvidia_drm ...)
 ```
 
 > [!WARNING]
+> Loading the Nvidia modules early may cause resuming from hibernation to not work anymore (i.e. the system will just boot instead of resuming).
+> If you have issues with that, try disabling early KMS.
+
+> [!WARNING]
 > Electron or Chromium-based apps can stall for up to a minute after boot on hybrid graphics systems with an Intel iGPU and an Nvidia dGPU.
 >
 > This can be fixed by loading the `i915` module **before** the Nvidia ones in `/etc/mkinitcpio.conf`. Just edit the `MODULES` line like this:
@@ -269,6 +273,10 @@ For Nix users, the equivalent of the above is
   hardware.nvidia.powerManagement.enable = true;
 }
 ```
+
+> [!WARNING]
+> [Loading the Nvidia modules early](https://wiki.hypr.land/Nvidia/#early-kms-modeset-and-fbdev) may cause resuming from hibernation to not work anymore (i.e. the system will just boot instead of resuming).
+> If you have issues with that, try disabling early KMS.
 
 > [!WARNING]
 > According to Nvidia, suspend/wakeup issues should be solved on the Nvidia open


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
Enabling early loading of the Nvidia modules can cause issues with hibernation: When resuming, the system will actually just reboot instead of resuming.

I added a warning in the early KMS section of the page, since that's what people installing hyprland will probably go through, and the same notice in the "Suspend/wakeup issues" section since that's where people will go if they have issues with that.