### PR TITLE
fix: add a newline after details closing tag

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -129,6 +129,7 @@ You can also compile it yourself by following the instructions
 [here](https://github.com/hyprwm/Hyprland/discussions/284)
 
 {{% /details %}}
+
 {{% details title="Debian*" closed="true" %}}
 
 Hyprland recently made it into the SID repository and can be installed with


### PR DESCRIPTION
Getting Started / Installation.md
- Added a newline after details closing tag. (Fixes instances like trying to render it with other parsers like remark)

Did it so it parses well on my single page application.

Without fix:
<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/f8471755-9e0c-4e5c-bb85-8061104b4be6" />

With Fix:

<img width="1430" height="985" alt="image" src="https://github.com/user-attachments/assets/c5858103-34cb-4798-9ec3-ce405ed4f07d" />

