### PR TITLE
Update Useful Utilities/Other: Replace hyprsome to split-monitor-workspaces

### DIFF
--- a/content/Useful Utilities/Other.md
+++ b/content/Useful Utilities/Other.md
@@ -8,7 +8,7 @@ above categories.
 
 ### Workspace management
 
-[hyprsome](https://github.com/sopa0/hyprsome) by _sopa0_: Awesome-like
+[split-monitor-workspaces](https://github.com/Duckonaut/split-monitor-workspaces) by _Stanisław Zagórowski_: Awesome-like
 workspaces for Hyprland.
 
 ### Keyboard layout management


### PR DESCRIPTION
Replace hyprsome to split-monitor-workspaces because hyprsome is archived.

https://github.com/sopa0/hyprsome/commit/a74d228af1da1e121e8904478e9eb90e00b4f597

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
