### PR TITLE
Installation: use hyproverlay for Gentoo

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -148,28 +148,30 @@ Alternatively, you can also follow the instructions under
 
 {{% details title="Gentoo*" closed="true" %}}
 
-The hyprland package is available in the main tree:
+The hypr packages are available in the [hyproverlay](https://codeberg.org/hyproverlay/hyproverlay). Enable the overlay with:
+
+```sh
+eselect repository enable hyproverlay
+emaint sync -r hyproverlay
+```
+
+Hyprland can be installed with:
 
 ```sh
 emerge --ask gui-wm/hyprland
 ```
 
 Additional packages like hyprlock, hypridle, xdg-desktop-portal-hyprland,
-hyprland-plugins, hyprpaper and hyprpicker are available in the
-[GURU](https://wiki.gentoo.org/wiki/Project:GURU) overlay. Community-contributed
-scripts are also available in GURU as part of the hyprland-contrib package.
+hyprland-plugins, hyprpaper and hyprpicker are in the overlay. Some of the community-contributed
+scripts of [hyprwm/contrib](https://github.com/hyprwm/contrib) are also available in their own package
+(app-misc/grimblast, app-misc/hdrop, etc.) .
 
 ```sh
-eselect repository enable guru
-emaint sync -r guru
-
 emerge --ask gui-apps/hyprlock
 emerge --ask gui-apps/hypridle
 emerge --ask gui-libs/xdg-desktop-portal-hyprland
-emerge --ask gui-apps/hyprland-plugins
 emerge --ask gui-apps/hyprpaper
 emerge --ask gui-apps/hyprpicker
-emerge --ask gui-wm/hyprland-contrib
 ```
 
 For USE flags and more details, read the


### PR DESCRIPTION
Due to the best-effort maintenance of the hypr packages in Gentoo, and because of the fast changes of dependencies, it has been decided to move these packages in their own overlay: https://codeberg.org/hyproverlay/hyproverlay

By being in an overlay, we can be faster to track the hypr releases. For example, Hyprland 0.53 needs a more recent glaze version than what is in Gentoo's repo, and this is stuck for weeks in this PR: https://github.com/gentoo/gentoo/pull/45126.
We ship glaze 6.X in the overlay, and are up-to-date on all hypr packages.

The discussion happened in Gentoo's IRC channels, the original discussion happened in this PR for 0.52.2: https://github.com/gentoo/gentoo/pull/44644#issuecomment-3765197231

Some packages from Guru have also been included in hyproverlay, with more packages to be added soon (either if one the maintainers use them, or on request).

After this PR is merged, the hyprland package in Gentoo will be transferred to hyproverlay. We'll wait for about a week to get more users and make sure that it works as expected before asking for the transfer.
We'll ask to transfer the packages from Guru as well, and we'll change Gentoo's wiki.