### PR TITLE
Useful Utilities/Other: add Monique

### DIFF
--- a/content/Useful Utilities/Other.md
+++ b/content/Useful Utilities/Other.md
@@ -74,6 +74,12 @@ exec-once = udiskie
 
 [See more uses here](https://github.com/coldfix/udiskie/wiki/Usage).
 
+### Monitor configuration
+
+[Monique](https://github.com/ToRvaLDz/monique) by _ToRvaLDz_: Graphical monitor
+configurator for Hyprland and Sway with drag-and-drop layout, profile system,
+and hotplug daemon for automatic configuration.
+
 ### Other useful utilities
 
 The website [We Are Wayland Now](https://wearewaylandnow.com/) details some other useful utilities and applications for Wayland like docks, email clients, and so on, along with some other useful information about compatibility on Wayland.


### PR DESCRIPTION
Add Monique to the Other utilities page under a new "Monitor configuration" section.

[Monique](https://github.com/ToRvaLDz/monique) (MONitor Integrated QUick Editor) is a graphical monitor configurator for Hyprland and Sway featuring:

- Drag-and-drop monitor layout
- Profile system with save/load/switch
- Hotplug daemon for automatic configuration
- SDDM integration
- Workspace rules

Built with Python, GTK4 and Libadwaita. Available on [AUR](https://aur.archlinux.org/packages/monique) and [PyPI](https://pypi.org/project/monique/).