### PR TITLE
Update hyprpolkitagent.md

### DIFF
--- a/content/Hypr Ecosystem/hyprpolkitagent.md
+++ b/content/Hypr Ecosystem/hyprpolkitagent.md
@@ -21,5 +21,5 @@ necessary to use
 `exec-once=/usr/lib64/libexec/hyprpolkitagent` instead.
 
 Other possible paths include
-`/usr/lib/hyprpolkitagent` and
+`/usr/lib/hyprpolkitagent/hyprpolkitagent` and
 `/usr/libexec/hyprpolkitagent`.


### PR DESCRIPTION
Hypr Ecosystem/Hyprpolkitagent : fixed other possible path


fixed other possible path to '/usr/lib/hyprpolkitagent/hyprpolkitagent' after discovering that the agent runs in the folder with the same name under /usr/lib/. Just including the former path in the hyprland.conf would not start the agent on startup.
 

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
