### PR TITLE
enhance(nix): Cachix

### DIFF
--- a/content/Nix/Cachix.md
+++ b/content/Nix/Cachix.md
@@ -11,30 +11,25 @@ The Hyprland flake is not built by Hydra, so it is not cached in
 [cache.nixos.org], like the rest of Nixpkgs.
 
 Instead of requiring you to build Hyprland (and its dependencies, which may
-include `mesa`, `ffmpeg`, etc), we provide a Cachix cache that you can add to
-your Nix configuration.
+include `mesa`, `ffmpeg`, etc), we provide the
+[Hyprland Cachix](https://app.cachix.org/cache/hyprland) cache that you can add
+to your Nix configuration.
 
-The [Hyprland Cachix](https://app.cachix.org/cache/hyprland) exists to cache the
-`hyprland` packages and any dependencies not found in [cache.nixos.org].
-
-> [!WARNING]
-> In order for Nix to take advantage of the cache, it has to be enabled **before**
-> using the Hyprland flake package.
-
-```nix {filename="configuration.nix"}
+```nix {filename="flake.nix"}
 {
-  nix.settings = {
-    substituters = ["https://hyprland.cachix.org"];
-    trusted-substituters = ["https://hyprland.cachix.org"];
-    trusted-public-keys = ["hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="];
+  nixConfig = {
+    extra-substituters = [
+      "https://hyprland.cachix.org/"
+    ];
+    extra-trusted-public-keys = [
+      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+    ];
   };
 }
 ```
 
 > [!WARNING]
->  Do **not** override Hyprland's `nixpkgs` input
-> unless you know what you are doing.  
-> Doing so will render the cache useless, since you're building from a different
-> Nixpkgs commit. 
+> Do **not** override Hyprland's `nixpkgs` input unless you know what you are doing.  
+> Doing so could cache miss and force a local Hyprland compilation. 
 
 [cache.nixos.org]: https://cache.nixos.org


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->

general enhancement, using the `flake.nix`'s `nixConfig` would scope the binary cache to the flake and doesn't require to enable it prior to adding the flake input 

hyprwm/Hyprland#13519 would also make it automatic

## References

- https://wiki.nixos.org/wiki/Binary_Cache#Binary_cache_hint_in_Flakes
- https://wiki.nixos.org/wiki/Flakes#Nix_configuration