### PR TITLE
Configuring/Keywords: update the list of unsupported per-device options

### DIFF
--- a/content/Configuring/Advanced and Cool/Devices.md
+++ b/content/Configuring/Advanced and Cool/Devices.md
@@ -25,8 +25,10 @@ Inside of it, put your config options. All options from the `input` category
 (and all subcategories, e.g. `input.touchpad`) can be put inside, **EXCEPT**:
 
 - `force_no_accel`
-- `follow_mouse`
-- `float_switch_override_focus`
+- Options that configure window management, such as: `follow_mouse`,
+  `follow_mouse_threshold`, `float_switch_override_focus`, `mouse_refocus`,
+  `special_fallthrough`, etc.
+
 
 You can also use the `output` setting for tablets to bind them to outputs.
 Remember to use the name of the `Tablet` and not `Tablet Pad` or `Tablet Tool`.


### PR DESCRIPTION
The list of options from the `input {}` block not supported by the `device {}` block was outdated. Added more options and the reason for why they are not supported.

IMO, grouping options configuring devices with options configuring window management is not the right design, so maybe the config should be restructured in the future. For now, just updating the docs.