### PR TITLE
Configuring/Layouts/Dwindle-Layout: remove pseudotile from example

### DIFF
--- a/content/Configuring/Layouts/Dwindle-Layout.md
+++ b/content/Configuring/Layouts/Dwindle-Layout.md
@@ -41,7 +41,6 @@ category name: `dwindle`
 ```lua
 hl.config({
   dwindle = {
-      pseudotile                   = false,
       force_split                  = 0,
       preserve_split               = false,
       smart_split                  = false,


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->

pseudotile is no longer real