### PR TITLE
Fix:  hugo security changes to allow local hyprland wiki generation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,8 +9,8 @@ pluralizeListTitles    = false
 disablePathToLower     = true
 
 [security.http]
-  urls = ['.*']
-
+  urls = ['(?i)^https?://[a-z]', '! (?i)localhost']
+  
 [outputs]
 home    = ["HTML"]
 page    = ["HTML"]

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,9 @@ languageCode           = 'en-us'
 pluralizeListTitles    = false
 disablePathToLower     = true
 
+[security.http]
+  urls = ['.*']
+
 [outputs]
 home    = ["HTML"]
 page    = ["HTML"]


### PR DESCRIPTION
hugo updated; tightened default security.

loosen it enough for local wiki to work