### PR TITLE
Configuring/Window Rules: Fix syntax in example expressions for size parameter

### DIFF
--- a/content/Configuring/Basics/Window-Rules.md
+++ b/content/Configuring/Basics/Window-Rules.md
@@ -140,7 +140,7 @@ Example expressions:
 
 ```lua
 move = "window_w*0.5 (monitor_h/2)+17"
-size = "(monitor_w*0.5) (monitor_h*0.5)"
+size = (monitor_w*0.5) (monitor_h*0.5)
 ```
 
 ### Dynamic effects


### PR DESCRIPTION
The syntax shown in the example doesn't actually work

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
