### PR TITLE
Configuring/Basics/Binds: Fixed a syntax issue with an example

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -281,7 +281,7 @@ to your config and you're done.
 This also means that push-to-talk will work flawlessly with one `pass`, e.g.:
 
 ```lua
-hl.bind("mouse:276", hl.dsp.pass("class:^(TeamSpeak 3)$"))    # Pass MOUSE5 to TeamSpeak3.
+hl.bind("mouse:276", hl.dsp.pass({window = "class:^(TeamSpeak 3)$"}))    # Pass MOUSE5 to TeamSpeak3.
 ```
 
 You may also add shortcuts, where other keys are passed to the window.


### PR DESCRIPTION
Fixed an issue with the teamspeak global bind passthrough example syntax