### PR TITLE
fix: correct Monitors redirect link in Useful Utilities

### DIFF
--- a/content/Useful Utilities/Screen-Sharing.md
+++ b/content/Useful Utilities/Screen-Sharing.md
@@ -11,9 +11,9 @@ Make sure you have `pipewire`, `wireplumber` and
 [`xdg-desktop-portal-hyprland`](../../Hypr-Ecosystem/xdg-desktop-portal-hyprland)
 installed, enabled and running if you don't have them yet.
 
-Ensure that the `bitdepth` set in your configuration 
+Ensure that the `bitdepth` set in your configuration
 matches that of your physical monitor.
-See [Monitors](../../Configuring/Monitors).
+See [Monitors](../../Configuring/Basics/Monitors).
 
 ## Screensharing
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
Fixes incorrect redirect link for the Monitors section in Useful Utilities.