### PR TITLE
IPC/index.md: update hyprctl doc link to correct path

### DIFF
--- a/content/IPC/_index.md
+++ b/content/IPC/_index.md
@@ -15,7 +15,7 @@ echo $HYPRLAND_INSTANCE_SIGNATURE
 ## `$XDG_RUNTIME_DIR/hypr/[HIS]/.socket.sock`
 
 Used for hyprctl-like requests. See the
-[Hyprctl page](../Configuring/Using-hyprctl) for commands.
+[Hyprctl page](../Configuring/Advanced-and-Cool/Using-hyprctl) for commands.
 
 basically, write `[flag(s)]/command args`.
 


### PR DESCRIPTION
The former link pointed to a page that didn't exist. I fixed it to point to the intended/actual one