### PR TITLE
Fix all 404 pages

### DIFF
--- a/content/Configuring/Advanced and Cool/Environment-variables.md
+++ b/content/Configuring/Advanced and Cool/Environment-variables.md
@@ -121,5 +121,5 @@ To force GBM as a backend, set the following environment variables:
   tools such as lxappearance or nwg-look.
 - `XCURSOR_THEME` - Set your cursor theme. The theme needs to be installed and
   readable by your user.
-- `XCURSOR_SIZE` - Set cursor size. See [here](../../FAQ/) for why you might
+- `XCURSOR_SIZE` - Set cursor size. See [here](../../FAQ) for why you might
   want this variable set.

--- a/content/Configuring/Advanced and Cool/Expanding-functionality.md
+++ b/content/Configuring/Advanced and Cool/Expanding-functionality.md
@@ -174,4 +174,4 @@ end)
 It's recommended to use Lua. Lua will be faster, less buggy, have more APIs,
 and is more integrated.
 
-However, if you want to use IPC instead, check the [IPC](../../IPC/) page.
+However, if you want to use IPC instead, check the [IPC](../../IPC) page.

--- a/content/Configuring/Advanced and Cool/Notifications.md
+++ b/content/Configuring/Advanced and Cool/Notifications.md
@@ -30,4 +30,4 @@ From hyprctl, you can create a notification with the `hyprctl notify` command:
 hyprctl notify [ICON] [TIME_MS] [COLOR] [MESSAGE]
 ```
 
-See more in [Using Hyprctl](/Configuring/Using-hyprctl/#notify)
+See more in [Using Hyprctl](./Using-hyprctl/#notify)

--- a/content/Configuring/Advanced and Cool/Using-hyprctl.md
+++ b/content/Configuring/Advanced and Cool/Using-hyprctl.md
@@ -31,7 +31,7 @@ Dispatch is a shorthand for `eval 'hl.dispatch(...)'`:
 hyprctl dispatch 'hl.dsp.focus({ workspace = "3" })'
 ```
 
-See [Dispatchers](../Dispatchers) for a list of dispatchers.
+See [Dispatchers](../Basics/Dispatchers) for a list of dispatchers.
 
 ### reload
 
@@ -173,7 +173,7 @@ Gets a property value of a window.
 hyprctl getprop [window] [property]
 ```
 
-Where `window` is as described [here](../Dispatchers#parameter-explanation), and `property` is any which can be set with [setprop](../Dispatchers/#setprop).
+Where `window` is as described [here](../Basics/Dispatchers#parameter-explanation), and `property` is any which can be set with [setprop](../Basics/Dispatchers/#setprop).
 
 #### Notes
 - If `animationstyle` is unset, `(unset)` is returned.
@@ -264,7 +264,7 @@ hyprctl getoption general.border_size
 hyprctl getoption input.touchpad.disable_while_typing
 ```
 
-See [Variables](../Variables) for sections and options you can use.
+See [Variables](../Basics/Variables) for sections and options you can use.
 
 ## Batch
 

--- a/content/Configuring/Advanced and Cool/XWayland.md
+++ b/content/Configuring/Advanced and Cool/XWayland.md
@@ -16,7 +16,7 @@ XWayland currently looks pixelated on HiDPI screens, due to Xorg's inability to
 scale.
 
 This problem is mitigated by the
-[`hl.config({ xwayland = { force_zero_scaling = true } })`](../Variables/#xwayland) option,
+[`hl.config({ xwayland = { force_zero_scaling = true } })`](../Basics/Variables/#xwayland) option,
 which forces XWayland windows not to be scaled.
 
 This will get rid of the pixelated look, but will not scale applications
@@ -53,7 +53,7 @@ for some kinds of sandboxes like Flatpak. However, removing the abstract socket
 has [potential](https://gitlab.gnome.org/GNOME/mutter/-/issues/1613) security
 and compatibility issues.
 
-Keeping that in mind, we add the [`xwayland:create_abstract_socket`](../Variables/#xwayland) option.
+Keeping that in mind, we add the [`xwayland:create_abstract_socket`](../Basics/Variables/#xwayland) option.
 When the abstract socket is disabled, only the regular Unix domain
 socket will be created.
 

--- a/content/Configuring/Basics/Autostart.md
+++ b/content/Configuring/Basics/Autostart.md
@@ -21,4 +21,4 @@ end)
 
 In the same vein, you can spawn processes on exit by listening to `hyprland.shutdown`.
 
-See more about `hl.on` over at [Expanding Functionality](../Advanced%20and%20Cool/Expanding-functionality.md)
+See more about `hl.on` over at [Expanding Functionality](../Advanced-and-Cool/Expanding-functionality.md)

--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -190,7 +190,7 @@ hl.bind("SUPER + Q", hl.dsp.exec_cmd("kitty"), { description = "Open my favourit
 ```
 
 If you want to access your description you can use `hyprctl binds`.  
-For more information have a look at [Using Hyprctl](../Using-hyprctl).
+For more information have a look at [Using Hyprctl](../Advanced-and-Cool/Using-hyprctl).
 
 ### Per-Device Binds
 
@@ -471,7 +471,7 @@ Variants are set per layout.
 > and the first letter on the first row while the `fr` layout is active.
 
 You can also bind a key to execute `hyprctl switchxkblayout` for more keybind
-freedom. See [Using hyprctl](../Using-hyprctl).
+freedom. See [Using hyprctl](../Advanced-and-Cool/Using-hyprctl).
 
 To find the valid layouts and `kb_options`, you can check out the
 `/usr/share/X11/xkb/rules/base.lst`. For example:

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -55,7 +55,7 @@ the layout pages and not here. (See the Sidebar for Dwindle and Master layouts)
 | resize_on_border | enables resizing windows by clicking and dragging on borders and gaps | bool | false |
 | extend_border_grab_area | extends the area around the border where you can click and drag on, only used when `general:resize_on_border` is on. | int | 15 |
 | hover_icon_on_border | show a cursor icon when hovering over borders, only used when `general:resize_on_border` is on. | bool | true |
-| allow_tearing | master switch for allowing tearing to occur. See [the Tearing page](../Tearing). | bool | false |
+| allow_tearing | master switch for allowing tearing to occur. See [the Tearing page](../Advanced-and-Cool/Tearing). | bool | false |
 | resize_corner | force floating windows to use a specific corner when being resized (1-4 going clockwise from top left, 0 to disable) | int | 0 |
 | modal_parent_blocking | whether parent windows of modals will be interactive | bool | true |
 | locale | overrides the system locale (e.g. en_US, es) | str | \[\[Empty\]\] |
@@ -154,7 +154,7 @@ _Subcategory `decoration.glow.`_
 | workspace_wraparound | enable workspace wraparound, causing directional workspace animations to animate as if the first and last workspaces were adjacent | bool | false |
 
 > [!NOTE]
-> _[More about Animations](../../advanced-and-cool/Animations)._
+> _[More about Animations](../Advanced-and-Cool/Animations)._
 
 ### Input
 
@@ -312,7 +312,7 @@ _Subcategory `gestures.`_
 > [!NOTE]
 > `workspace_swipe`, `workspace_swipe_fingers` and `workspace_swipe_min_fingers` were removed in favor of the new gestures system.
 > 
-> You can add this gesture config to replicate the swiping functionality with 3 fingers. See the [gestures](../Gestures) page for more info.
+> You can add this gesture config to replicate the swiping functionality with 3 fingers. See the [gestures](../Advanced-and-Cool/Gestures) page for more info.
 > 
 > ```ini
 > gesture = 3, horizontal, workspace
@@ -460,7 +460,7 @@ _Subcategory `xwayland.`_
 | enabled | allow running applications using X11 | bool | true |
 | use_nearest_neighbor | uses the nearest neighbor filtering for xwayland apps, making them pixelated rather than blurry | bool | true |
 | force_zero_scaling | forces a scale of 1 on xwayland windows on scaled displays. | bool | false |
-| create_abstract_socket | Create the [abstract Unix domain socket](../XWayland/#abstract-unix-domain-socket) for XWayland connections. (XWayland restart is required for changes to take effect; Linux only) | bool | false |
+| create_abstract_socket | Create the [abstract Unix domain socket](../Advanced-and-Cool/XWayland/#abstract-unix-domain-socket) for XWayland connections. (XWayland restart is required for changes to take effect; Linux only) | bool | false |
 
 ### OpenGL
 
@@ -527,11 +527,11 @@ _Subcategory `cursor.`_
 
 _Subcategory `ecosystem.`_
 
-| name | description | type | default |
-| --- | --- | --- | --- |
+| name | description                                                              | type | default |
+| --- |--------------------------------------------------------------------------| --- | --- |
 | no_update_news | disable the popup that shows up when you update hyprland to a new version. | bool | false |
-| no_donation_nag | disable the popup that shows up twice a year encouraging to donate. | bool | false |
-| enforce_permissions | whether to enable [permission control](../Permissions). | bool | false |
+| no_donation_nag | disable the popup that shows up twice a year encouraging to donate.      | bool | false |
+| enforce_permissions | whether to enable [permission control](../Advanced-and-Cool/Permissions).                  | bool | false |
 
 ### Quirks
 

--- a/content/Configuring/Basics/Workspace-Rules.md
+++ b/content/Configuring/Basics/Workspace-Rules.md
@@ -12,7 +12,7 @@ instance, you can define a workspace where all windows are drawn without borders
 or gaps.
 
 For layout-specific rules, see the specific layout page. For example:
-[Master Layout->Workspace Rules](../Master-Layout#workspace-rules).
+[Master Layout->Workspace Rules](../Layouts/Master-Layout#workspace-rules).
 
 ## Syntax
 

--- a/content/FAQ/_index.md
+++ b/content/FAQ/_index.md
@@ -53,7 +53,7 @@ by fractional amounts.
 To force them to run in native Wayland mode, see
 [the Master Tutorial](../Getting-Started/Master-Tutorial/#force-apps-to-use-wayland).
 
-If they can't, see [the XWayland page](../Configuring/XWayland).
+If they can't, see [the XWayland page](../Configuring/Advanced-and-Cool/XWayland).
 
 ### My external monitor is blank / doesn't render / receives no signal (laptop)
 
@@ -296,7 +296,7 @@ taste.
 
 ### How do I export envvars for Hyprland?
 
-See [Environment Variables](../Configuring/Environment-variables)
+See [Environment Variables](../Configuring/Advanced-and-Cool/Environment-variables)
 
 The `env` keyword is used for this purpose. For example:
 
@@ -457,11 +457,11 @@ This means you have no hyprcursor theme installed, and hyprland failed to find a
 
 ### Smart gaps please?
 
-[Here](../Configuring/Workspace-Rules/#smart-gaps).
+[Here](../Configuring/Basics/Workspace-Rules/#smart-gaps).
 
 ### Hyprwinwrap is not visible through blurred windows
 
-This is a side effect of the [decoration:blur:new_optimizations](../Configuring/Variables/#blur).
+This is a side effect of the [decoration:blur:new_optimizations](../Configuring/Basics/Variables/#blur).
 You have two options to resolve it.
 1. Set `decoration:blur:new_optimizations` to `false` - This will preserve the exact same appearance, but may have a slight performance cost.
 2. Set `decoration:blur:ignore_opacity` to `false` - This will drastically affect the appearance, but should maintain the original performance.

--- a/content/Getting Started/Master-Tutorial.md
+++ b/content/Getting Started/Master-Tutorial.md
@@ -96,7 +96,7 @@ crucial things to make Wayland / Hyprland / other apps work correctly.
 
 ## Monitors config
 
-See [Configuring Hyprland page](../../Configuring/Monitors) to learn all about
+See [Configuring Hyprland page](../Configuring/Basics/Monitors) to learn all about
 configuring your displays.
 
 ## Apps / X11 replacements
@@ -141,7 +141,7 @@ For most electron apps, you should put the above in
 it.
 
 A few more environment variables for forcing Wayland mode are documented
-[here](../../Configuring/Environment-variables).
+[here](../Configuring/Advanced-and-Cool/Environment-variables).
 
 You can check whether an app is running in xwayland or not with
 `hyprctl clients`.

--- a/content/Hypr Ecosystem/hyprlock.md
+++ b/content/Hypr Ecosystem/hyprlock.md
@@ -97,7 +97,7 @@ animation = fade, 1, 1.8, linear
 Available animations can be found in the [animation tree](#animation-tree).
 The optional `STYLE` parameter for the `animation` keyword is currently unused by hyprlock.
 
-Check out Hyprland's [animation documentation](../../Configuring/Animations) for more information.
+Check out Hyprland's [animation documentation](../Configuring/Animations) for more information.
 
 #### Animation Tree
 
@@ -128,7 +128,7 @@ The following keys and key-combinations describe hyprlock's default behaviour:
 | `Ctrl + u` | Clear password buffer |
 | `Ctrl + Backspace` | Clear password buffer |
 
-The [bind flag](../../Configuring/Binds/#bind-flags) `l` can be used to allow specific hyprland keybinds to also work while hyprlock is active (e.g. brightness/volume/media control).
+The [bind flag](../Configuring/Basics/Binds/#bind-flags) `l` can be used to allow specific hyprland keybinds to also work while hyprlock is active (e.g. brightness/volume/media control).
 
 ## Widgets
 
@@ -147,7 +147,7 @@ widget_name {
 It takes the same string that is used to reference monitors in the hyprland configuration.
 So either use the portname (e.g. `eDP-1`) or the monitor description (e.g. `desc:Chimei Innolux Corporation 0x150C`).
 
-See [Monitors](../../Configuring/Monitors).
+See [Monitors](../Configuring/Basics/Monitors).
 
 ### Variable Substitution
 The following variables in widget text options will be substituted.
@@ -230,7 +230,7 @@ If `path` is `screenshot`, a screenshot of your desktop at launch will be used.
 
 > [!NOTE]
 > Blur options are taken from hyprland.
-> See [Variables/#blur](../../Configuring/Variables/#blur).
+> See [Variables/#blur](../Configuring/Basics/Variables/#blur).
 
 {{% details title="Example background" closed="true" %}}
 

--- a/content/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
+++ b/content/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
@@ -162,7 +162,7 @@ If you see a crash, it's likely you are missing either `qt6-wayland` or
 `qt5-wayland`.
 
 If the portal does not autostart, does not function when manually started,
-and does not produce any error logs, it's very likely your [XDG env variables](../../Configuring/Environment-variables/#xdg-specifications)
+and does not produce any error logs, it's very likely your [XDG env variables](../Configuring/Advanced-and-Cool/Environment-variables/#xdg-specifications)
 are messed up
 
 ## Configuration

--- a/content/IPC/_index.md
+++ b/content/IPC/_index.md
@@ -15,7 +15,7 @@ echo $HYPRLAND_INSTANCE_SIGNATURE
 ## `$XDG_RUNTIME_DIR/hypr/[HIS]/.socket.sock`
 
 Used for hyprctl-like requests. See the
-[Hyprctl page](../Configuring/Using-hyprctl) for commands.
+[Hyprctl page](../Configuring/Advanced-and-Cool/Using-hyprctl) for commands.
 
 basically, write `[flag(s)]/command args`.
 

--- a/content/Nvidia/_index.md
+++ b/content/Nvidia/_index.md
@@ -230,7 +230,7 @@ If you experience issues with multi-monitor setup on a hybrid graphics device
 Nvidia doesn't support important features for Multi-GPU which can result in a broken or slow setup.
 There are some workarounds to try:
 
-1. Try changing the primary GPU [with the AQ_DRM_DEVICES environment variable](https://wiki.hypr.land/Configuring/Multi-GPU/#telling-hyprland-which-gpu-to-use).
+1. Try changing the primary GPU [with the AQ_DRM_DEVICES environment variable](../Configuring/Advanced-and-Cool/Multi-GPU/#telling-hyprland-which-gpu-to-use).
 2. Try setting the environment variable `AQ_FORCE_LINEAR_BLIT=0` to not force linear modifiers on Multi-GPU buffers.
 
 This might slow down rendering to secondary monitors and make Hyprland a bit laggy on them,

--- a/content/Plugins/Using-Plugins.md
+++ b/content/Plugins/Using-Plugins.md
@@ -30,7 +30,7 @@ manual instructions, see [here](#manual).
 ### hyprpm
 
 > [!NOTE]
-> If you are using [permission management](../../Configuring/Permissions),
+> If you are using [permission management](../Configuring/Advanced-and-Cool/Permissions),
 > you should allow hyprpm to load plugins by adding this to your config:
 > 
 > ```ini

--- a/content/Useful Utilities/Screen-Sharing.md
+++ b/content/Useful Utilities/Screen-Sharing.md
@@ -13,7 +13,7 @@ installed, enabled and running if you don't have them yet.
 
 Ensure that the `bitdepth` set in your configuration 
 matches that of your physical monitor.
-See [Monitors](../../Configuring/Monitors).
+See [Monitors](../Configuring/Basics/Monitors).
 
 ## Screensharing
 

--- a/content/Useful Utilities/Status-Bars.md
+++ b/content/Useful Utilities/Status-Bars.md
@@ -308,7 +308,7 @@ and a [guided hello world](https://quickshell.outfoxxed.me/docs/configuration/in
 
 ### Blur
 
-Use the `blur` and `ignore_alpha` [layer rules](https://wiki.hypr.land/Configuring/Window-Rules/#layer-rules). 
+Use the `blur` and `ignore_alpha` [layer rules](../Configuring/Basics/Window-Rules/#layer-rules). 
 The former enables blur, and the latter makes it ignore insufficiently opaque regions. 
 Ideally, the value used with `ignore_alpha` is higher than the shadow opacity and lower than the bar/menu content's opacity. 
 Additionally, if it has transparent popups, you can use the `blur_popups` rule.

--- a/content/Useful Utilities/Systemd-start.md
+++ b/content/Useful Utilities/Systemd-start.md
@@ -50,7 +50,7 @@ For more info, read the [option](https://search.nixos.org/options?channel=unstab
 ## Launching Hyprland with uwsm
 
 > [!NOTE]
-> Pay attention to the warnings in [Environment variables](../../Configuring/Environment-variables), [Multi-GPU](../../Configuring/Multi-GPU) and [Dispatchers](../../Configuring/Dispatchers) sections.
+> Pay attention to the warnings in [Environment variables](../Configuring/Advanced-and-Cool/Environment-variables), [Multi-GPU](../Configuring/Advanced-and-Cool/Multi-GPU) and [Dispatchers](../Configuring/Basics/Dispatchers) sections.
 
 ### In tty
 


### PR DESCRIPTION
It should be all pages that currently are 404.

But I don't know why we have https://wiki.hypr.land/Configuring/Hypr-Ecosystem/xdg-desktop-portal-hyprland
showing up at https://wiki.hypr.land/Configuring/Basics/Binds because it has `[XDPH](../../Hypr-Ecosystem/xdg-desktop-portal-hyprland)` and should resolve correctly.

There's also this:

```
Broken URL: https://wiki.hypr.land/Configuring/Useful-Utilities/Systemd-start
Referenced from:
  - https://wiki.hypr.land/Configuring/Advanced-and-Cool/Environment-variables
  - https://wiki.hypr.land/Configuring/Advanced-and-Cool/Multi-GPU
  - https://wiki.hypr.land/Configuring/Basics/Dispatchers
```
