### PR TITLE
Several fixes / improvements

### DIFF
--- a/content/Configuring/Basics/Autostart.md
+++ b/content/Configuring/Basics/Autostart.md
@@ -13,7 +13,7 @@ Autostarting apps can be done by executing things on the `hyprland.start` event:
 hl.on("hyprland.start", function () 
   hl.exec_cmd(terminal)
   hl.exec_cmd("nm-applet")
-  hl.exec_cmd("waybar & hyprpaper & firefox")
+  hl.exec_cmd("waybar & hyprpaper & firefox") -- Execute waybar, hyprpaper, firefox
 end)
 ```
 

--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -70,7 +70,7 @@ A monitor. Can be:
 
 | method | description |
 | --- | --- |
-| `exec_cmd(cmd, rules?)` | execute a command. Rules can be a table of window rule effects to apply. |
+| `exec_cmd(cmd, rules?)` | execute a command. Rules can be a table of window rule effects to apply (see [below](#executing-with-rules)). |
 | `exec_raw(cmd)` | execute a raw command. While `exec_cmd` will do `bash -c`, this won't. |
 | `focus({ direction })` | move the focus in a direction |
 | `focus({ monitor })` | move the focus to a monitor |
@@ -101,7 +101,7 @@ A monitor. Can be:
 | `signal({ signal, window? })` | send a signal to a window process |
 | `float({ action?, window? })` | set a window's floating state. |
 | `fullscreen({ mode?, action?, window? })` | set a window's fullscreen state. `mode` can be "maximized" and "fullscreen". `action` can be `toggle`/`set`/`unset` |
-| `fullscreen_state({ internal, client, action?, window? })` | set a window's fullscreen state with more precision. `action` can be `toggle`/`set`/`unset` |
+| `fullscreen_state({ internal, client, action?, window? })` | set a window's fullscreen state with more precision. `action` can be `toggle`/`set`/`unset`. See [Fullscreenstate](#fullscreenstate) |
 | `pseudo({ action?, window? })` | set a window's pseudotiling state. |
 | `move({ direction })` | move a window in a direction |
 | `move({ workspace, follow? })` | move a window to a workspace |
@@ -235,7 +235,25 @@ workspace that you can toggle on/off on any monitor.
 > You can define multiple named special workspaces, but the amount of those is
 > limited to 97 at a time.
 
-### setprop
+For example, to move a window to a named special workspace you can use the following syntax:
+
+```lua
+hl.bind("SUPER + C", hl.dsp.window.move({ workspace = "special:magic" }))
+-- To see the hiden window and workspace you can use: 
+hl.bind("SUPER + S", hl.dsp.workspace.toggle_special("magic"))
+```
+
+## Executing with rules 
+
+The `exec_cmd` dispatcher supports adding rules. Please note some windows might work better, some worse. It records the PID of the spawned process and uses that. For example, if your process forks and then the fork opens a window, this will not work.
+
+Example:
+
+```lua
+hl.bind("SUPER + E", hl.dsp.exec_cmd("kitty", { float = true, move = {0, 0} }))
+```
+
+## setprop
 
 Props are any of the _dynamic effects_ of [Window Rules](../Window-Rules#dynamic-effects).
 
@@ -250,7 +268,7 @@ Some props are expanded from their window rule parents which take multiple argum
 - `border_color` -> `active_border_color`, `inactive_border_color`
 - `opacity` -> `opacity`, `opacity_inactive`, `opacity_fullscreen`, `opacity_override`, `opacity_inactive_override`, `opacity_fullscreen_override`
 
-### Fullscreenstate
+## Fullscreenstate
 
 The `fullscreen_state` dispatcher decouples the state that Hyprland maintains for a window from the fullscreen state that is communicated to the client.  
 

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -18,11 +18,11 @@ the layout pages and not here. (See the Sidebar for Dwindle and Master layouts)
 | type | description |
 | --- | --- |
 | int | integer |
-| bool | boolean |
+| bool | boolean (`true` or `false`) |
 | float | floating point number |
 | color | color (see hint below for color info) |
 | vec2 | vector with 2 float values (e.g. `{ 20, 20 }`) |
-| str | a string |
+| str | a string (wrapped into "", e.g: `"dwindle"`) |
 | gradient | a gradient, will accept a color, or `{ colors = { "rgba(...)", "rgba(...)" }, angle? = 45 }` |
 | font_weight | an integer between 100 and 1000, or one of the following presets: `thin` `ultralight` `light` `semilight` `book` `normal` `medium` `semibold` `bold` `ultrabold` `heavy` `ultraheavy` |
 | css_gaps | an integer, or `{ top?, left?, right?, bottom? }` |

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -315,8 +315,12 @@ _Subcategory `gestures.`_
 > 
 > You can add this gesture config to replicate the swiping functionality with 3 fingers. See the [gestures](../../Advanced-and-Cool/Gestures) page for more info.
 > 
-> ```ini
-> gesture = 3, horizontal, workspace
+> ```lua
+> hl.gesture({
+>    fingers = 3,
+>    direction = "horizontal",
+>    action = "workspace"
+> })
 > ```
 
 ### Group

--- a/content/Configuring/Basics/Window-Rules.md
+++ b/content/Configuring/Basics/Window-Rules.md
@@ -112,7 +112,7 @@ which will be found when matching on `title` and `class`, respectively.
 | fullscreen | boolean | Fullscreens a window. |
 | maximize | boolean | Maximizes a window. |
 | fullscreen_state | string | Sets the fullscreen mode, e.g. `"1 2"` (internal client). Values: `0` none, `1` maximize, `2` fullscreen, `3` maximize and fullscreen. |
-| move | string | Moves a floating window to a given coordinate, monitor-local. E.g. `{100, 200}` or `"{"cursor_x-(window_w*0.5))", "(cursor_y-(window_h*0.5))"}`. |
+| move | string | Moves a floating window to a given coordinate, monitor-local. E.g. `{100, 200}` or `{"cursor_x-(window_w*0.5))", "(cursor_y-(window_h*0.5))"}`. |
 | size | string | Resizes a floating window. E.g. `{800, 600}` or `{"(monitor_w*0.5)", "(monitor_h*0.5)"}`. |
 | center | boolean | If the window is floating, will center it on the monitor. |
 | pseudo | boolean | Pseudotiles a window. |
@@ -239,8 +239,8 @@ hl.window_rule({ match = { tag = "term" },         tag = "-code" })   -- Remove 
 Or with a keybind for convenience:
 
 ```lua
-hl.bind("SUPER + CTRL + 2", function() hl.dispatch(hl.dsp.window.tag({ tag = "alpha_0.2" })))
-hl.bind("SUPER + CTRL + 4", function() hl.dispatch(hl.dsp.window.tag({ tag = "alpha_0.4" })))
+hl.bind("SUPER + CTRL + 2", hl.dsp.window.tag({ tag = "alpha_0.2" }))
+hl.bind("SUPER + CTRL + 4", hl.dsp.window.tag({ tag = "alpha_0.4" }))
 hl.window_rule({ match = { tag = "alpha_0.2" }, opacity = "0.2 override" })
 hl.window_rule({ match = { tag = "alpha_0.4" }, opacity = "0.4 override" })
 ```

--- a/content/Crashes and Bugs/_index.md
+++ b/content/Crashes and Bugs/_index.md
@@ -5,8 +5,8 @@ title: Crashes and Bugs
 
 ## Getting the log
 
-Firstly, make sure you have enabled logs in the Hyprland config. Set `debug:disable_logs` to `false`.
-then to make OpenGL produce error messages set `debug:gl_debugging` to `true`.
+Firstly, make sure you have enabled logs in the Hyprland config. Set `debug.disable_logs` to `false`.
+then to make OpenGL produce error messages set `debug.gl_debugging` to `true`.
 
 dont forget to disable these when done logging as they cause a performance hit.
 

--- a/content/FAQ/_index.md
+++ b/content/FAQ/_index.md
@@ -247,10 +247,10 @@ taste.
 
 See [Environment Variables](../Configuring/Advanced-and-Cool/Environment-variables)
 
-The `env` keyword is used for this purpose. For example:
+The `hl.env()` function is used for this purpose. For example:
 
-```ini
-env = XDG_CURRENT_DESKTOP,Hyprland
+```lua
+hl.env("XDG_CURRENT_DESKTOP", "Hyprland")
 ```
 
 ### How to disable middle-click paste?

--- a/content/Nvidia/_index.md
+++ b/content/Nvidia/_index.md
@@ -121,9 +121,9 @@ More information is available
 
 Add these variables to your Hyprland config:
 
-```ini
-env = LIBVA_DRIVER_NAME,nvidia
-env = __GLX_VENDOR_LIBRARY_NAME,nvidia
+```lua
+hl.env("LIBVA_DRIVER_NAME", "nvidia")
+hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
 ```
 
 ### Finishing up
@@ -148,8 +148,8 @@ Electron and CEF apps flicker because:
 To enable native Wayland support for most Electron apps, add this
 environment variable to your config:
 
-```ini
-env = ELECTRON_OZONE_PLATFORM_HINT,auto
+```lua
+hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 ```
 
 This has been confirmed to work on Vesktop, VSCodium, Obsidian and will probably
@@ -204,8 +204,8 @@ will be given here:
    repos.
 
 2. Add this variable to your Hyprland config:
-   ```ini
-   env = NVD_BACKEND,direct
+   ```lua
+   hl.env("NVD_BACKEND", "direct")
    ```
 
    See


### PR DESCRIPTION
While migrating configs, I found some missing info. This PR resolves them.

## Full changes list:
- `Basics/Dispatchers.md`: Added section about `exec_cmd` with rules, special workspace bind examples, 
- `Basics/Variables.md`: Added clarifying about `string` and `bool` 
- `Basics/Window-Rules.md`: Removed lambdas in window.tag() example
- `FAQ, Nvidia`: Replace old `env =` examples with `hl.env()`
- `Basics/Autostart.md`: Added a comment to "waybar & hyprpaper & firefox" (It seems very confusing at glance)
- `Basics/Variables.md`: Replace old gesture example with `hl.gesture()`
- Misc: Some links, typos, headings fixes and replacements of `:` config option indexing with `.` 