### PR TITLE
Configuring/Advanced-and-Cool/XWayland/: Fix missing = sign on XWayla…

### DIFF
--- a/content/Configuring/Advanced and Cool/XWayland.md
+++ b/content/Configuring/Advanced and Cool/XWayland.md
@@ -28,7 +28,7 @@ hl.monitor({ output = "", mode = "highres", position = "auto", scale = "2" })
 
 -- unscale XWayland
 hl.config({
-  xwayland {
+  xwayland = {
     force_zero_scaling = true
   }
 })


### PR DESCRIPTION
Missing equal sign on the XWayland configuration
