### PR TITLE
Configuring/Advanced and Cool/Animations: fix typo and wording in enabled

### DIFF
--- a/content/Configuring/Advanced and Cool/Animations.md
+++ b/content/Configuring/Advanced and Cool/Animations.md
@@ -17,7 +17,7 @@ hl.animation({ leaf = STRING, enabled = BOOLEAN, speed = FLOAT, curve = STRING[,
 ```
 `leaf` is scope of the animation. See [Animation tree](#animation-tree)
 
-`enable` use `true` to disable, `false` to enable. _Note:_ if it's `false`, you
+`enabled` use `true` to enable, `false` to disable. _Note:_ if it's `false`, you
 can omit further args.
 
 `speed` is the amount of ds (1ds = 100ms) the animation will take. For example `speed = 1` = 100ms


### PR DESCRIPTION
This PR fixes a typo and improves the wording in the `enabled` field description for animations.

The previous description used `enable` instead of `enabled` and also stated:

> use `true` to disable, `false` to enable

which was reversed and inconsistent with the examples shown below it.

The updated wording now correctly reflects the actual behavior:

- `true` enables the animation
- `false` disables it