### PR TITLE
Configuring: fix typos & update syntax to lua

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -274,7 +274,7 @@ Let's take OBS as an example: the "Start/Stop Recording" keybind is set to
 <key>SUPER</key> + <key>F10</key>, to make it work globally, simply add:
 
 ```lua
-hl.bind("SUPER + F10", hl.dsp.pass("class:^(com\.obsproject\.Studio)$"))
+hl.bind("SUPER + F10", hl.dsp.pass({ window = "class:^(com\\.obsproject\\.Studio)$" }))
 ```
 
 to your config and you're done.

--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -45,7 +45,7 @@ If no window is provided, the active window is used.
 A workspace. Can be:
  - workspace object
  - workspace ID
- - workspace selector, see [below]({{< relref "#workspace selectors" >}})
+ - workspace selector, see [below](#workspace-selectors)
 
 #### Direction
 

--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -190,9 +190,7 @@ You can lock a group with the `lock` dispatcher in order to stop new
 windows from entering this group.
 
 You can prevent a window from being added to a group or becoming a group with the
-`window.deny_from_group` dispatcher. `move({ window_or_group })` will behave like
-`move({ window })` if the current active window or window in direction has this property
-set.
+`window.deny_from_group` dispatcher.
 
 ## Workspace selectors
 

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -195,7 +195,7 @@ _Subcategory `decoration.glow.`_
 | repeat_rate | The repeat rate for held-down keys, in repeats per second. | int | 25 |
 | repeat_delay | Delay before a held-down key is repeated, in milliseconds. | int | 600 |
 | sensitivity | Sets the mouse input sensitivity. Value is clamped to the range -1.0 to 1.0. [libinput#pointer-acceleration](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration) | float | 0.0 |
-| accel_profile | Sets the cursor acceleration profile. Can be one of `adaptive`, `flat`. Can also be `custom`, see [below](#custom-accel-profiles). Leave empty to use `libinput`'s default mode for your input device. [libinput#pointer-acceleration](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration) [adaptive/flat/custom]| str | \[\[Empty\]\] |
+| accel_profile | Sets the cursor acceleration profile. Can be one of `adaptive`, `flat`. Can also be `custom`, see [below](#accel_profile). Leave empty to use `libinput`'s default mode for your input device. [libinput#pointer-acceleration](https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration) [adaptive/flat/custom]| str | \[\[Empty\]\] |
 | force_no_accel | Force no cursor acceleration. This bypasses most of your pointer settings to get as raw of a signal as possible. **Enabling this is not recommended due to potential cursor desynchronization.** | bool | false |
 | rotation | Sets the rotation of a device in degrees clockwise off the logical neutral position. Value is clamped to the range 0 to 359. | int | 0 |
 | left_handed | Switches RMB and LMB | bool | false |

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -473,8 +473,8 @@ _Subcategory `binds.`_
 | workspace_center_on | Whether switching workspaces should center the cursor on the workspace (0) or on the last active window for that workspace (1) | int | 0 |
 | focus_preferred_method | sets the preferred focus finding method when using `hl.dsp.focus({ direction })`/`hl.dsp.window.move({ direction })`/etc. 0 - history (recent have priority), 1 - length (longer shared edges have priority) | int | 0 |
 | ignore_group_lock | If enabled, dispatchers like `hl.dsp.window.move({ into_group })` and `hl.dsp.window.move({ out_of_group })` will ignore lock per group. | bool | false |
-| movefocus_cycles_fullscreen | If enabled, when on a fullscreen window, `movefocus` will cycle fullscreen, if not, it will move the focus in a direction. | bool | false |
-| movefocus_cycles_groupfirst | If enabled, when in a grouped window, movefocus will cycle windows in the groups first, then at each ends of tabs, it'll move on to other windows/groups | bool | false |
+| movefocus_cycles_fullscreen | If enabled, when on a fullscreen window, `hl.dsp.focus({ direction })` will cycle fullscreen, if not, it will move the focus in a direction. | bool | false |
+| movefocus_cycles_groupfirst | If enabled, when in a grouped window, `hl.dsp.focus({ direction })` will cycle windows in the groups first, then at each ends of tabs, it'll move on to other windows/groups | bool | false |
 | window_direction_monitor_fallback | If enabled, moving a window or focus over the edge of a monitor with a direction will move it to the next monitor in that direction. | bool | true |
 | disable_keybind_grabbing | If enabled, apps that request keybinds to be disabled (e.g. VMs) will not be able to do so. | bool | false |
 | allow_pin_fullscreen | If enabled, Allow fullscreen to pinned windows, and restore their pinned status afterwards | bool | false |

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -72,7 +72,7 @@ end
 | gaps_workspaces | gaps between workspaces. Stacks with gaps_out. | css_gaps | 0 |
 | col.inactive_border | border color for inactive windows | gradient | 0xff444444 |
 | col.active_border | border color for the active window | gradient | 0xffffffff |
-| col.nogroup_border | inactive border color for window that cannot be added to a group (see `denywindowfromgroup` dispatcher) | gradient | 0xffffaaff |
+| col.nogroup_border | inactive border color for window that cannot be added to a group (see `hl.dsp.window.deny_from_group` dispatcher) | gradient | 0xffffaaff |
 | col.nogroup_border_active | active border color for window that cannot be added to a group | gradient | 0xffff00ff |
 | layout | which layout to use. \[dwindle/master/scrolling/monocle\] | str | dwindle |
 | no_focus_fallback | if true, will not fall back to the next available window when moving focus in a direction where no window was found | bool | false |
@@ -471,8 +471,8 @@ _Subcategory `binds.`_
 | hide_special_on_workspace_change | If enabled, changing the active workspace (including to itself) will hide the special workspace on the monitor where the newly active workspace resides. | bool | false |
 | allow_workspace_cycles | If enabled, workspaces don't forget their previous workspace, so cycles can be created by switching to the first workspace in a sequence, then endlessly going to the previous workspace. | bool | false |
 | workspace_center_on | Whether switching workspaces should center the cursor on the workspace (0) or on the last active window for that workspace (1) | int | 0 |
-| focus_preferred_method | sets the preferred focus finding method when using `focuswindow`/`movewindow`/etc with a direction. 0 - history (recent have priority), 1 - length (longer shared edges have priority) | int | 0 |
-| ignore_group_lock | If enabled, dispatchers like `moveintogroup`, `moveoutofgroup` and `movewindoworgroup` will ignore lock per group. | bool | false |
+| focus_preferred_method | sets the preferred focus finding method when using `hl.dsp.focus({ direction })`/`hl.dsp.window.move({ direction })`/etc. 0 - history (recent have priority), 1 - length (longer shared edges have priority) | int | 0 |
+| ignore_group_lock | If enabled, dispatchers like `hl.dsp.window.move({ into_group })` and `hl.dsp.window.move({ out_of_group })` will ignore lock per group. | bool | false |
 | movefocus_cycles_fullscreen | If enabled, when on a fullscreen window, `movefocus` will cycle fullscreen, if not, it will move the focus in a direction. | bool | false |
 | movefocus_cycles_groupfirst | If enabled, when in a grouped window, movefocus will cycle windows in the groups first, then at each ends of tabs, it'll move on to other windows/groups | bool | false |
 | window_direction_monitor_fallback | If enabled, moving a window or focus over the edge of a monitor with a direction will move it to the next monitor in that direction. | bool | true |

--- a/content/Configuring/Layouts/Master-Layout.md
+++ b/content/Configuring/Layouts/Master-Layout.md
@@ -18,7 +18,7 @@ than the default left/right split.
 
 ## Config
 
-_category name `master` (`hl.config({ master = {...} })`)
+category name `master` (`hl.config({ master = {...} })`)
 
 | name | description | type | default |
 | --- | --- | --- | --- |

--- a/content/Configuring/Layouts/Monocle-Layout.md
+++ b/content/Configuring/Layouts/Monocle-Layout.md
@@ -16,7 +16,7 @@ Monocle is a layout where windows are always taking up the entire available spac
 ## Quirks
 
 Due to how layouts work, `hl.dsp.window.cycle_next()` will not work with Monocle. For cycling monocle
-windows, either use `hl.dsp.layout("cyclenext")` or `hl.dsp.window.cycle_next("tiled")`.
+windows, either use `hl.dsp.layout("cyclenext")` or `hl.dsp.window.cycle_next({ tiled = true })`.
 
 ## Layout messages
 


### PR DESCRIPTION
Note about commit `Configuring/Basics/Dispatchers: remove mention of movewindoworgroup dispatcher`:
I couldn't find anything about dispatchers `move({ window_or_group })` and `move({ window })`, so I assume they were removed in v0.55.0?