### PR TITLE
Hypr Ecosystem/hypridle: updated dpms dispatcher syntax

### DIFF
--- a/content/Hypr Ecosystem/hypridle.md
+++ b/content/Hypr Ecosystem/hypridle.md
@@ -73,9 +73,9 @@ Full hypridle example with hyprlock:
 
 ```ini
 general {
-    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
-    before_sleep_cmd = loginctl lock-session    # lock before suspend.
-    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+    lock_cmd = pidof hyprlock || hyprlock                                     # avoid starting multiple hyprlock instances.
+    before_sleep_cmd = loginctl lock-session                                  # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch 'hl.disp.dpms({ action = "enable" })'  # to avoid having to press a key twice to turn on the display.
 }
 
 listener {
@@ -97,9 +97,9 @@ listener {
 }
 
 listener {
-    timeout = 330                                                     # 5.5min
-    on-timeout = hyprctl dispatch dpms off                            # screen off when timeout has passed
-    on-resume = hyprctl dispatch dpms on && brightnessctl -r          # screen on when activity is detected after timeout has fired.
+    timeout = 330                                                                                  # 5.5min
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'                            # screen off when timeout has passed
+    on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })' && brightnessctl -r          # screen on when activity is detected after timeout has fired.
 }
 
 listener {


### PR DESCRIPTION
`hyprctl dispatch dpms {on|off}` -> `hyprctl dispatch 'hl.dsp.dpms({ action = "{enable|disable}" })`

fixes #1481 