### PR TITLE
Fix incorrect syntax in global binds section

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -274,7 +274,7 @@ Let's take OBS as an example: the "Start/Stop Recording" keybind is set to
 <key>SUPER</key> + <key>F10</key>, to make it work globally, simply add:
 
 ```lua
-hl.bind("SUPER + F10", hl.dsp.pass("class:^(com\.obsproject\.Studio)$"))
+hl.bind("SUPER + F10", hl.dsp.pass({ window = "class:^(com\\.obsproject\\.Studio)$" }))
 ```
 
 to your config and you're done.


### PR DESCRIPTION
fixes #1485.

I realized after making a PR to a different repository fixing Lua stuff that the actual syntax was not exactly hard to come by, and having gained that knowledge decided to open a PR for my original issue.

This fixes the argument to the `hl.dsp.pass` dispatcher function by providing a table with a window parameter instead of a plain string. This also fixes the previously incorrectly escaped dot-character in the regex string.