### PR TITLE
Configuring/Basics/Binds: fix example for submaps

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -329,10 +329,10 @@ hl.bind("ALT + R", hl.dsp.submap("resize"))
 hl.define_submap("resize", function()
 
     -- Set repeating binds for resizing the active window.
-    hl.bind("right", hl.resize({ x = 10, y = 0, relative = true}), { repeating = true })
-    hl.bind("left", hl.resize({ x = -10, y = 0, relative = true}), { repeating = true })
-    hl.bind("up", hl.resize({ x = 0, y = 10, relative = true}), { repeating = true })
-    hl.bind("down", hl.resize({ x = 10, y = -10, relative = true}), { repeating = true })
+    hl.bind("right", hl.dsp.window.resize({ x = 10, y = 0, relative = true}), { repeating = true })
+    hl.bind("left", hl.dsp.window.resize({ x = -10, y = 0, relative = true}), { repeating = true })
+    hl.bind("up", hl.dsp.window.resize({ x = 0, y = 10, relative = true}), { repeating = true })
+    hl.bind("down", hl.dsp.window.resize({ x = 0, y = -10, relative = true}), { repeating = true })
 
     -- Use `reset` to go back to the global submap
     hl.bind("escape", hl.dsp.submap("reset"))


### PR DESCRIPTION
The submap example (a submap for resizing windows) on the Binds page does not work as intended for two reasons:
- The dispatchers are not called correctly
- The keybind for reducing the height of a window simultaneously increased its width

This fixes both of these issues.