### PR TITLE
Update Status-Bars.md by removing calendar workaround

### DIFF
--- a/content/Useful Utilities/Status-Bars.md
+++ b/content/Useful Utilities/Status-Bars.md
@@ -78,8 +78,7 @@ If you are using multiple monitors, you may want to insert the following option:
 - Ashell is ready to use out of the box. Just install it, start using it, and customize only what you need.
 - Ashell comes with essential modules like workspaces, time, battery, network, and more. No need to hunt for plugins or write custom scripts.
 - Powered by iced. A cross-platform GUI library for Rust
-- Has a pretty limited configuration options. It's a good and a bad thing at the same time. You can get a very decent result quickly and with a little effort, but some tricky waybar-alike tweaks are not possible.
-- Calendar is absent but in the [roadmap](https://github.com/MalpenZibo/ashell/issues/181)
+- Has a pretty limited configuration options. It's a good and a bad thing at the same time. You can get a very decent result quickly and with a little effort, but some crazy waybar-alike tweaks are not possible.
 
 
 ### Noctalia
@@ -90,19 +89,6 @@ If you are using multiple monitors, you may want to insert the following option:
 - Notification system with history and Do Not Disturb.
 - Plugin support.
 - Built on Quickshell.
-
-
-#### Workaround for calendar
-
-```toml
-[modules]
-center = [ "calendar", "Clock" ]
-# ...
-[[CustomModule]]
-name = "calendar"
-icon = ""
-command = "zenity --calendar --title=\"Calendar\""
-```
 
 ## Widget systems
 


### PR DESCRIPTION
Removed workaround for calendar as it was
- related to ashell and noctalia
- not relevant anymore. ashell provides powerful calendar out of the box

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
