### PR TITLE
Configuring/Basics/Binds: Fixed example for switchable keyboard layout

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -448,7 +448,7 @@ example:
 hl.config({
     input =  {
 	kb_layout = "us,cz",
-	kb_variant = "qwerty",
+	kb_variant = ",qwerty",
 	kb_options = "grp:alt_shift_toggle"
     }
 })


### PR DESCRIPTION
Without the comma the conf would throw an error:
`[runtime error] Invalid keyboard layout passed`

It was in the old syntax however this one comma didn't make it through
```
input {
    kb_layout = us,cz
    kb_variant = ,qwerty
    kb_options = grp:alt_shift_toggle
}
```