### PR TITLE
Useful Utilities/Screenshots-and-Recording.md: add missing quote in bind example

### DIFF
--- a/content/Useful Utilities/Screenshots-and-Recording.md
+++ b/content/Useful Utilities/Screenshots-and-Recording.md
@@ -34,7 +34,7 @@ To copy a selected area directly to the clipboard, install
 [`wl-clipboard`](https://github.com/bugaevc/wl-clipboard) and use:
 
 ```lua
-hl.bind("SUPER + Print", hl.dsp.exec_cmd('grim -g "$(slurp -d)" - | wl-copy))
+hl.bind("SUPER + Print", hl.dsp.exec_cmd('grim -g "$(slurp -d)" - | wl-copy'))
 ```
 
 ### Satty


### PR DESCRIPTION
The error can be found in line 37 of [Screenshots-and-Recording.md](https://github.com/hyprwm/hyprland-wiki/blob/main/content/Useful%20Utilities/Screenshots-and-Recording.md).

```lua
hl.bind("SUPER + Print", hl.dsp.exec_cmd('grim -g "$(slurp -d)" - | wl-copy))
```

should be:

 ```lua
hl.bind("SUPER + Print", hl.dsp.exec_cmd('grim -g "$(slurp -d)" - | wl-copy'))
```

Fixes issue #1512