### PR TITLE
Configuring/Basics/Dispatchers: clarify `hl.dsp.window.{close,kill,signal}`

### DIFF
--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -96,9 +96,9 @@ A monitor. Can be:
 
 | method | description |
 | --- | --- |
-| `close(window?)` | Close a window. |
-| `kill(window?)` | Kill a window |
-| `signal({ signal, window? })` | send a signal to a window process |
+| `close(window?)` | Send a graceful request to close the window. |
+| `kill(window?)` | Kill the process owning the window with a `SIGKILL`. |
+| `signal({ signal, window? })` | Send a POSIX signal to the process owning the window. |
 | `float({ action?, window? })` | set a window's floating state. |
 | `fullscreen({ mode?, action?, window? })` | set a window's fullscreen state. `mode` can be "maximized" and "fullscreen". `action` can be `toggle`/`set`/`unset` |
 | `fullscreen_state({ internal, client, action?, window? })` | set a window's fullscreen state with more precision. `action` can be `toggle`/`set`/`unset`. See [Fullscreenstate](#fullscreenstate) |


### PR DESCRIPTION
The meaning of "close" and "kill" needs to be clear. I just had a few processes killed when I meant just to close windows.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
