### PR TITLE
docs(variables): fix rgba example + prefer_hdr period

### DIFF
--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -54,7 +54,7 @@ end
 > 
 > You have 4 options:
 > - web-styled hash, e.g. `"#fafc21"` or `"#ddd"` or `"#fa3d7bff"` (rgba order)
-> - rgba(), e.g. `"rgba(b3ff1aee)`, or the decimal equivalent `"rgba(179,255,26,0.933)"`
+> - rgba(), e.g. `"rgba(b3ff1aee)"`, or the decimal equivalent `"rgba(179,255,26,0.933)"`
 > (decimal rgba/rgb values should have no spaces between numbers)
 > - rgb(), e.g. `"rgb(b3ff1a)"`, or the decimal equivalent  `"rgb(179,255,26)"`
 > - legacy, e.g. `0xeeb3ff1a` -> ARGB order
@@ -581,7 +581,7 @@ _Subcategory `quirks.`_
 | --- | --- | --- | --- |
 | prefer_hdr | Report HDR mode as preferred. 0 - off, 1 - always, 2 - gamescope only | int | `0` |
 
-Some clients expect monitor to be in HDR mode prior to the client start. This breaks auto HDR activation and can cause whitescreen and flickering. Use `prefer_hdr` to fix it,
+Some clients expect monitor to be in HDR mode prior to the client start. This breaks auto HDR activation and can cause whitescreen and flickering. Use `prefer_hdr` to fix it.
 
 ### Debug
 


### PR DESCRIPTION
## Summary

Closes #1517. Two small typos under `content/Configuring/Basics/Variables.md`:

- Line 57 (under `#variable-types`, colors info box): the `rgba()` example was missing its closing quotation mark - shown as `"rgba(b3ff1aee)` rather than `"rgba(b3ff1aee)"`. The surrounding examples on the same and adjacent lines are correctly quoted.
- Line 584 (under `#quirks`, prefer_hdr paragraph): the explanation sentence ended in a comma instead of a period - `Use prefer_hdr to fix it,` -> `Use prefer_hdr to fix it.`.

## Why this matters

Both reading-flow issues for users who land on the colors/quirks sections. The colors example is the canonical reference for how to write rgba literals in Hyprland configs, and the inconsistent quoting reads as a syntax mistake on the user's part. The trailing comma on the prefer_hdr paragraph makes the closing thought feel cut off.

## How to test

```
$ grep -n "rgba(b3ff1aee)" content/Configuring/Basics/Variables.md
57:> - rgba(), e.g. `"rgba(b3ff1aee)"`, or the decimal equivalent `"rgba(179,255,26,0.933)"`

$ grep -n "prefer_hdr to fix" content/Configuring/Basics/Variables.md
584:Some clients expect monitor to be in HDR mode prior to the client start. This breaks auto HDR activation and can cause whitescreen and flickering. Use `prefer_hdr` to fix it.
```

Fixes #1517

AI-assisted.
