### PR TITLE
Binds: fix config example code block (syntax error)

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -220,7 +220,7 @@ These are binds that rely on mouse movement. They will have one less arg.
 
 ```lua
 hl.config({
-    binds {
+    binds = {
         drag_threshold = 10 -- Fire a drag event only after dragging for more than 10px
     }
 })


### PR DESCRIPTION
Little syntax typo fix :) 
from 
<img width="1560" height="499" alt="image" src="https://github.com/user-attachments/assets/259a10e9-d7e3-4eb3-96cf-7f875c5043f6" />
to 
<img width="1547" height="499" alt="image" src="https://github.com/user-attachments/assets/612830f8-4bf1-41c6-811f-9c96488297bc" />
