### PR TITLE
Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md: fix one spelling mistake

### DIFF
--- a/content/Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md
+++ b/content/Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md
@@ -44,7 +44,7 @@ end)
 
 For less distractions at a keypress, or battery saving on a laptop
 
-Add the following to your hypland config:
+Add the following to your hyprland config:
 
 ```lua
 hl.bind("SUPER + F1", function ()


### PR DESCRIPTION
Fix one typo:
- `hypland` --> `hyprland`