### PR TITLE
Recommend uwsm users to enable hyprsunset as a service

### DIFF
--- a/content/Hypr Ecosystem/hyprsunset.md
+++ b/content/Hypr Ecosystem/hyprsunset.md
@@ -77,7 +77,7 @@ profile {
 ## Usage
 
 To autostart hyprsunset, add: `hyprsunset` to your `hyprland.lua`'s autostart.
-Alternatively, use `systemctl --user enable --now hyprsunset.service` in order to use hyprsunset as a systemd user service.
+If Hyprland is started with [uwsm](../../Useful-Utilities/Systemd-start), you can use `systemctl --user enable --now hyprsunset.service`.
 
 Hyprsunset can also be controlled by supplying arguments to the command.  
 By specifying `hyprsunset --temperature 5000` you will override the current active config's temperature setting.  This however, will be overridden once a new profile is activated.


### PR DESCRIPTION
The wiki mentioned the systemd service for [hyprsunset](https://wiki.hypr.land/Hypr-Ecosystem/hyprsunset/#usage) as an alternative, instead of recommendation for uwsm users unlike [hypridle's wiki](https://wiki.hypr.land/Hypr-Ecosystem/hypridle/#configuration).

Closes #1141 