### PR TITLE
Fix typos on `‎content/Configuring/Layouts/Scrolling-Layout.md`

### DIFF
--- a/content/Configuring/Layouts/Scrolling-Layout.md
+++ b/content/Configuring/Layouts/Scrolling-Layout.md
@@ -25,8 +25,8 @@ category name: `scrolling` (`hl.config({ scrolling = {...} })`)
 | follow_focus | when a window is focused, should the layout move to bring it into view automatically | bool | `true` |
 | follow_min_visible | when a window is focused, require that at least a given fraction of it is visible for focus to follow. Hard input (e.g. binds, clicks) will always follow. [0.0 - 1.0] | float | `0.4` |
 | explicit_column_widths | A comma-separated list of preconfigured widths for colresize +conf/-conf | str | `"0.333, 0.5, 0.667, 1.0"` |
-| wrap_focus | When enabled, causes `hl.dsp.layoutmsg("focus l/r")` to wrap around at the beginning and end. | bool | `true` |
-| wrap_swapcol | When enabled, causes `hl.dsp.layoutmsg("swapcol l/r")` to wrap around at the beginning and end. | bool | `true` |
+| wrap_focus | When enabled, causes `hl.dsp.layout("focus l/r")` to wrap around at the beginning and end. | bool | `true` |
+| wrap_swapcol | When enabled, causes `hl.dsp.layout("swapcol l/r")` to wrap around at the beginning and end. | bool | `true` |
 | direction | Direction in which new windows appear and the layout scrolls. `"left"`/`"right"`/`"down"`/`"up"` | str | `"right"` |
 
 ## Workspace rules


### PR DESCRIPTION
Fixing two typos I found when I was setting up my config