### PR TITLE
Configuring/Basics/Binds: rename 'bypass' flag to 'dont_inhibit'

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -88,7 +88,7 @@ Available flags:
 | `transparent` | Cannot be shadowed by other binds. |
 | `ignore_mods` | Will ignore modifiers. |
 | `description` | Will allow you to write a description for your bind. |
-| `bypass` | Bypasses the app's requests to inhibit keybinds. |
+| `dont_inhibit` | Bypasses the app's requests to inhibit keybinds. |
 | `submap_universal` | Will be active no matter the submap. |
 | `device` | Allow binds to be set per device. See [Per-Device Binds](#per-device-binds) |
 


### PR DESCRIPTION
In Binds the docs claims there's a `bypass` flag, but this flag does not exist in the code, instead it's expecting `dont_inhibit`.

The discussion that led to this MR and the solution found by [NotTomFoolery](https://github.com/NotTomFoolery):
https://github.com/hyprwm/Hyprland/discussions/14483#discussioncomment-16911281

