### PR TITLE
Correctly mark `hl.dsp.window.pin` as accepting `action` argument

### DIFF
--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -119,7 +119,7 @@ A monitor. Can be:
 | `tag({ tag, window? })` | tag a window |
 | `clear_tags({ window? })` | clear all tags from a window |
 | `toggle_swallow()` | toggle all swallowed windows visible |
-| `pin({ window? })` | pin a window |
+| `pin({ action?, window? })` | pin a window |
 | `alter_zorder({ mode, window? })` | mode can be "top" or "bottom" |
 | `set_prop({ prop, value, window? })` | set a window property |
 | `deny_from_group({ action? })` | deny a window from entering a group |


### PR DESCRIPTION
Experimentally, it does support this