### PR TITLE
Document new `stableid` window selector

### DIFF
--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -33,6 +33,7 @@ A window. Can be:
    - `tag:...`
  - exact selectors:
    - `pid:...`
+   - `stableid:...`
    - `address:0x...`
  - `activewindow`
  - `floating`


### PR DESCRIPTION
Docs for hyprwm/Hyprland#14984

Not much to say here, other than listing `stableid:...` as a new selector. Should be obvious that values to use for this are obtainable from `hyprctl clients` or whatever.