### PR TITLE
docs(nix): document trusted-users requirement for Cachix

### DIFF
--- a/content/Nix/Cachix.md
+++ b/content/Nix/Cachix.md
@@ -27,9 +27,17 @@ The [Hyprland Cachix](https://app.cachix.org/cache/hyprland) exists to cache the
     substituters = ["https://hyprland.cachix.org"];
     trusted-substituters = ["https://hyprland.cachix.org"];
     trusted-public-keys = ["hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="];
+    # Required so non-root users are allowed to use the above substituter/keys.
+    # Use @wheel for all sudo users, or list your username explicitly.
+    trusted-users = ["root" "@wheel"];
   };
 }
 ```
+
+> [!NOTE]
+> If you see `ignoring the client-specified setting 'trusted-public-keys',
+> because it is a restricted setting and you are not a trusted user`, your user
+> is not in `trusted-users`. Add it as shown above and rebuild.
 
 > [!WARNING]
 >  Do **not** override Hyprland's `nixpkgs` input


### PR DESCRIPTION
## Summary
Documents the required `trusted-users` setting on content/Nix/Cachix.md so the Hyprland Cachix substituter and keys are not silently ignored for non-trusted users.

Fixes #1271
