### PR TITLE
systemd: add general instructions for starting graphical-session

### DIFF
--- a/content/Configuring/Basics/Autostart.md
+++ b/content/Configuring/Basics/Autostart.md
@@ -22,3 +22,4 @@ end)
 In the same vein, you can spawn processes on exit by listening to `hyprland.shutdown`.
 
 See more about `hl.on` over at [Expanding Functionality](../../Advanced-and-Cool/Expanding-functionality)
+and [systemd](../../../Useful-Utilities/Systemd-start#autostart) for autostarting user services.

--- a/content/Getting Started/Master-Tutorial.md
+++ b/content/Getting Started/Master-Tutorial.md
@@ -41,8 +41,7 @@ Please bear in mind 3D acceleration in VMs may be pretty slow.
 
 Hyprland can be executed by typing `start-hyprland` in your tty.
 
-If you are adventurous and on systemd, you can also try uwsm. Please note uwsm has some issues and for the majority of users, it's recommended to use Hyprland without it.
-Uwsm provides additional features such as [xdg-autostart](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html) support, launching any application as a systemd-unit with `uwsm app` helper, and the ability to enable services for programs that rely on a graphical session and provide such services (e.g waybar). See [uwsm](../../Useful-Utilities/Systemd-start) page for further instructions.
+If you are on systemd, some services like XDG Desktop Portal may **require** you to start a proper graphical session with systemd. Systemd also provides additional features such as [xdg-autostart](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html) support, launching any application as a systemd-unit, and the ability to enable services for programs that rely on a graphical session and provide such services (e.g waybar). See the [systemd page](../../Useful-Utilities/Systemd-start) for further instructions.
 
 
 > [!WARNING]

--- a/content/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
+++ b/content/Hypr Ecosystem/xdg-desktop-portal-hyprland.md
@@ -99,6 +99,10 @@ See
 
 ## Usage
 
+> [!WARNING]
+> The systemd `xdg-desktop-portal.service` may require an active `graphical-session.target`,
+> which Hyprland doesn't start by default. See [systemd](../../Useful-Utilities/Systemd-start) to set that up.
+
 XDPH is automatically started by D-Bus, once Hyprland starts.
 
 To check if everything is OK is, try to screenshare anything, or opening OBS and

--- a/content/Useful Utilities/Systemd-start.md
+++ b/content/Useful Utilities/Systemd-start.md
@@ -7,9 +7,9 @@ title: Systemd startup
 
 - [Universal Wayland Session Manager](https://github.com/Vladimir-csp/uwsm) wraps standalone Wayland compositors into a set of Systemd units and provides robust session management including environment, XDG autostart support, bi-directional binding with login session, and clean shutdown.
 
-Please note uwsm is for advanced users and has its issues and additional quirks.
+Please note uwsm is for advanced users and has its issues and additional quirks. [hyprland-session.target](#hyprland-sessiontarget) is an alternative minimal way of handling a systemd session.
 
-## Installation
+### Installation
 
 {{% details title="Arch" closed="true" %}}
 
@@ -47,12 +47,12 @@ For more info, read the [option](https://search.nixos.org/options?channel=unstab
 > [!NOTE]
 > For instructions for other distros and manual building, see [building and installing](https://github.com/Vladimir-csp/uwsm?tab=readme-ov-file#installation) section on the project's page.
 
-## Launching Hyprland with uwsm
+### Launching Hyprland with uwsm
 
 > [!NOTE]
 > Pay attention to the warnings in [Environment variables](../../Configuring/Advanced-and-Cool/Environment-variables), [Multi-GPU](../../Configuring/Advanced-and-Cool/Multi-GPU) and [Dispatchers](../../Configuring/Basics/Dispatchers) sections.
 
-### In tty
+#### In tty
 
 {{% details title="GNOME Keyring PAM setup" closed="true" %}}
 
@@ -95,11 +95,11 @@ if uwsm check may-start; then
 fi
 ```
 
-### Using a display manager
+#### Using a display manager
 
 If you use a display manager, choose `Hyprland (uwsm-managed)` entry in a display manager selection menu.
 
-## Launching applications inside session
+### Launching applications inside session
 
 The concept of a session managed by Systemd implies also running applications as units. Uwsm [provides](https://github.com/Vladimir-csp/uwsm#3-applications-and-slices) a helper to do it. Running applications as child processes inside compositor's unit is discouraged.
 
@@ -110,10 +110,42 @@ Faster alternatives are:
 - `app2unit`: ([link](https://github.com/Vladimir-csp/app2unit)), pure shell alternative, file opener, usually ahead on features.
 - `runapp`: ([link](https://github.com/c4rlo/runapp/)), C++ alternative, even faster, features may vary.
 
+## hyprland-session.target
+
+A Wayland compositor is expected to tell systemd that it is a graphical session. This is a minimal way of starting the `graphical-session.target` if you don't want to use UWSM. This target will autostart user services like bars and notification daemons, but some services like XDG Desktop Portal (and therefore XDPH) may even refuse to start without it. You can manage this yourself by creating a `hyprland-session.target` that binds to the `graphical-session.target`, then launching it in your config.
+
+First create the unit with `systemctl --user edit --full --force hyprland-session.target`:
+
+```ini
+[Unit]
+Description=Hyprland session
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target
+PropagatesStopTo=graphical-session.target
+```
+
+Then start and stop it in your config:
+
+```lua
+hl.on("hyprland.start", function()
+    hl.exec_cmd("systemctl --user start hyprland-session.target")
+end)
+
+hl.on("hyprland.shutdown", function()
+    os.execute("systemctl --user stop hyprland-session.target && sleep 0.1")
+    -- uses a blocking exec function and sleeps a bit to give things time to close
+    -- you might also want to kill troublesome/crashing non-systemd background services here:
+    -- os.execute("pkill wallpaperthing; systemctl --user stop hyprland-session.target && sleep 0.1")
+end)
+```
+
 ## Autostart
 
-XDG Autostart is handled by systemd, and its target is activated in uwsm-managed session automatically.
+XDG Autostart is handled by systemd, and its target is activated in uwsm-managed session automatically. User services usually require `graphical-session.target` to be activated by any method on this page.
 
 Some applications provide native systemd user units to be autostarted with. Those might need to be enabled explicitly via `systemctl --user enable [some-app.service]`. Or, in case the unit is missing `[Install]` section, enabled more directly: `systemctl --user add-wants graphical-session.target [some-app.service]`. Also ensure the unit has `After=graphical-session.target` ordering (it can be added via drop-in).
+
+For example, instead of having `hl.exec_cmd("hyprpaper")` in your config, simply run `systemctl --user enable hyprpaper.service` once and have systemd launch it for you from now on.
 
 More autostart-related examples and tricks can be found [here](https://github.com/Vladimir-csp/uwsm/tree/master/example-units).


### PR DESCRIPTION
Adds some general instructions how to start a graphical-session without uwsm. XDP might revert their requirement, but this is still valuable information required for using any user services.

I have also made a patch to automatically do this in Hyprland, but that might not be desirable by all. https://github.com/hyprwm/Hyprland/compare/main...Dregu:Hyprland:session-target