### PR TITLE
Configuring/Advanced and Cool/Uncommon-tips-and-tricks: fix broken minimize windows

### DIFF
--- a/content/Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md
+++ b/content/Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md
@@ -32,11 +32,13 @@ This approach uses special workspaces to mimic the “minimize window” functio
 
 ```lua
 hl.bind("SUPER + X", function ()
-    hl.dispatch(hl.dsp.workspace.toggle_special("minimize"))
-    hl.dispatch(hl.dsp.window.move({workspace = "+0"}))
-    hl.dispatch(hl.dsp.workspace.toggle_special("minimize"))
-    hl.dispatch(hl.dsp.window.move({workspace = "special:minimize"}))
-    hl.dispatch(hl.dsp.workspace.toggle_special("minimize"))
+    if hl.get_workspace("special:minimized") then
+        hl.dispatch(hl.dsp.window.move({ workspace = hl.get_active_workspace(), window = "tag:minimized" }))
+        hl.dispatch(hl.dsp.window.clear_tags({ window = "tag:minimized" }))
+    else
+        hl.dispatch(hl.dsp.window.tag({ tag = "minimized", window = hl.get_active_window() }))
+        hl.dispatch(hl.dsp.window.move({ workspace = "special:minimized", follow = false }))
+    end
 end)
 ```
 


### PR DESCRIPTION
The current method to minimize windows with special workspaces does not work. I found a fix for it using tags.