### PR TITLE
Configuring/Basics/Window-Rules: Add event listener example to static rule warning

### DIFF
--- a/content/Configuring/Basics/Window-Rules.md
+++ b/content/Configuring/Basics/Window-Rules.md
@@ -104,6 +104,16 @@ which will be found when matching on `title` and `class`, respectively.
 > It is not possible to `float` (or any other static rule) a window based on a
 > change in the `title` after the window has been created. This applies to all
 > static effects listed here.
+> Instead, use a [dispatch](../Dispatchers#window-1) triggered by an
+> [event](../../Advanced-and-Cool/Expanding-functionality#events) listener to
+> apply the effect after the window has been created:
+> ```lua
+> hl.on("window.title", function(w)
+>     if w ~= nil and w.title == "foo" then
+>         hl.dispatch(hl.dsp.window.float({ action = "set" }))
+>     end
+> end)
+> ```
 
 | Effect | Argument | Description |
 | ---- | ----------- | --- |


### PR DESCRIPTION
Improves the warning about rules based on a change in the `title` after the window has been created by recommending an event listener which triggers a dispatch.
