### PR TITLE
Configuring/Basics/Dispatchers.md: add missing curly braces to `close and `kill`

### DIFF
--- a/content/Configuring/Basics/Dispatchers.md
+++ b/content/Configuring/Basics/Dispatchers.md
@@ -97,8 +97,8 @@ A monitor. Can be:
 
 | method | description |
 | --- | --- |
-| `close(window?)` | Send a graceful request to close the window. |
-| `kill(window?)` | Kill the process owning the window with a `SIGKILL`. |
+| `close({ window? })` | Send a graceful request to close the window. |
+| `kill({ window? })` | Kill the process owning the window with a `SIGKILL`. |
 | `signal({ signal, window? })` | Send a POSIX signal to the process owning the window. |
 | `float({ action?, window? })` | set a window's floating state. |
 | `fullscreen({ mode?, action?, window? })` | set a window's fullscreen state. `mode` can be "maximized" and "fullscreen". `action` can be `toggle`/`set`/`unset` |


### PR DESCRIPTION
title