### PR TITLE
Useful Utilities/Status-Bars: update waybar workspaces scroll commands for the new dispatchers' Lua API change

### DIFF
--- a/content/Useful Utilities/Status-Bars.md
+++ b/content/Useful Utilities/Status-Bars.md
@@ -49,8 +49,8 @@ look like this:
 ```json
 "hyprland/workspaces": {
      "format": "{icon}",
-     "on-scroll-up": "hyprctl dispatch workspace e+1",
-     "on-scroll-down": "hyprctl dispatch workspace e-1"
+     "on-scroll-up": "hyprctl dispatch 'hl.dsp.focus({workspace=\"e+1\"})' ",
+     "on-scroll-down": "hyprctl dispatch 'hl.dsp.focus({workspace=\"e-1\"})' ",
 }
 ```
 


### PR DESCRIPTION
The Hyprland Lua API changed how workspace dispatch is handled,
replacing direct `hyprctl dispatch workspace` calls with the new
`hl.dsp.focus` interface.

Update scroll bindings in hyprland/workspaces to match the new API
for workspace navigation.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
