### PR TITLE
Documentation for system bell Lua event and sound customization variable

### DIFF
--- a/content/Configuring/Advanced and Cool/Expanding-functionality.md
+++ b/content/Configuring/Advanced and Cool/Expanding-functionality.md
@@ -53,6 +53,7 @@ Event list:
 | window.fullscreen | Emitted when the fullscreen status of a window changes. | Window |
 | window.update_rules | Emitted when a window's rules are re-evaluated, e.g. when its title or class changes. | Window |
 | window.move_to_workspace | Emitted when a window is moved to a different workspace. | Window, Workspace |
+| window.bell | Emitted when a window rings the system bell, even if it's muted. | Window |
 | layer.opened | Emitted when a layer surface is opened. | LayerSurface |
 | layer.closed | Emitted when a layer surface is closed. | LayerSurface |
 | monitor.added | Emitted when a monitor is connected and ready. | Monitor |

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -483,6 +483,7 @@ _Subcategory `misc.`_
 | size_limits_tiled | whether to apply min_size and max_size rules to tiled windows | bool | `false` |
 | screencopy_force_8b | forces 8 bit screencopy | bool | `true` |
 | disable_watchdog_warning | whether to disable the warning about not using start-hyprland | bool | `false` |
+| bell_sound | path to custom ogg/wav system bell. "none" or an empty string mute it. "default" causes Hyprland to search for the system-defined one. | str | `"default"` |
 
 ### Layout
 

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -483,7 +483,7 @@ _Subcategory `misc.`_
 | size_limits_tiled | whether to apply min_size and max_size rules to tiled windows | bool | `false` |
 | screencopy_force_8b | forces 8 bit screencopy | bool | `true` |
 | disable_watchdog_warning | whether to disable the warning about not using start-hyprland | bool | `false` |
-| bell_sound | path to custom ogg/wav system bell. "none" or an empty string mute it. "default" causes Hyprland to search for the system-defined one. | str | `"default"` |
+| bell_sound | path to custom wav/ogg system bell. "none" or an empty string mute it. "default" causes Hyprland to search for the system-defined one. | str | `"default"` |
 
 ### Layout
 

--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -498,7 +498,7 @@ _Subcategory `misc.`_
 | size_limits_tiled | whether to apply min_size and max_size rules to tiled windows | bool | `false` |
 | screencopy_force_8b | forces 8 bit screencopy | bool | `true` |
 | disable_watchdog_warning | whether to disable the warning about not using start-hyprland | bool | `false` |
-| bell_sound | path to custom wav/ogg system bell. "none" or an empty string mute it. "default" causes Hyprland to search for the system-defined one. | str | `"default"` |
+| bell_sound | path to custom wav/ogg system bell. "none" or an empty string mute it. "default" uses the system's current one. | str | `"default"` |
 | float_force_onscreen | whether/how existing floating windows should be constrained to stay on-screen. 0 - no constraints, 1 - must be partially onscreen, 2 - must be fully onscreen [0/1/2] | int | `0` |
 | new_float_force_onscreen | same as `float_force_onscreen`, but specifically for newly-spawned floating windows [0/1/2] | int | `2` |
 


### PR DESCRIPTION
The wiki entries regarding https://github.com/hyprwm/Hyprland/pull/15502.

- Documentation in Variables under misc for the `bell_sound` variable.
- Documentation in Expanding functionality for the `window.bell` event.