### PR TITLE
Configuring/Basics/Variables: add binds:drag_center_window

### DIFF
--- a/content/Configuring/Basics/Variables.md
+++ b/content/Configuring/Basics/Variables.md
@@ -513,6 +513,7 @@ _Subcategory `binds.`_
 | disable_keybind_grabbing | If enabled, apps that request keybinds to be disabled (e.g. VMs) will not be able to do so. | bool | `false` |
 | allow_pin_fullscreen | If enabled, Allow fullscreen to pinned windows, and restore their pinned status afterwards | bool | `false` |
 | drag_threshold | Movement threshold in pixels for window dragging and c/g bind flags. 0 to disable and grab on mousedown. | int | `0` |
+| drag_center_window | If enabled, dragging a tiled or fullscreen window will center it on the cursor when it becomes floating. | bool | `true` | "
 
 ### XWayland
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->
Currently when dragging a window from a tiled position or fullscreen it moves itself to center itself on the mouse, this PR adds an option to disable this behavior and instead just move based on the mouse cursors delta, via setting binds:drag_center_window to false. Defaults to true so current behavior is unchanged.

Hyper PR: hyprwm/Hyprland#15563