### PR TITLE
Configuring/Start: mention Hyprlang migration helper

### DIFF
--- a/content/Configuring/Start.md
+++ b/content/Configuring/Start.md
@@ -6,6 +6,8 @@ title: ⮞⮞ Start Here ⮜⮜
 > [!NOTE]
 > Looking for the old hyprlang syntax? Check the [0.54 wiki pages](https://wiki.hypr.land/0.54.0/).
 > Since Hyprland 0.55, hyprlang is deprecated in favor of lua.
+> The third-party [hyprmorph](https://github.com/junaga/hyprmorph) converter can
+> provide a Lua starting point; review its warnings and generated output before use.
 
 The config is located in `$XDG_CONFIG_HOME/hypr/hyprland.lua`. In most cases,
 that maps to `~/.config/hypr/hyprland.lua`.


### PR DESCRIPTION
Adds a small third-party note for people moving an old Hyprlang config to Lua.

It points to hyprmorph as a starting point and reminds readers to review the output.

Checked the Markdown diff and project link.
