### PR TITLE
FAQ/_index.md: fix silent workspace autostart example

### DIFF
--- a/content/FAQ/_index.md
+++ b/content/FAQ/_index.md
@@ -203,7 +203,7 @@ hl.on("hyprland.start", function ()
   hl.exec_cmd("kitty")
   hl.exec_cmd("dolphin")
   hl.exec_cmd("dunst")
-  hl.exec_cmd("amongus", { workspace = "1" })
+  hl.exec_cmd("amongus", { workspace = "1 silent" })
 end)
 ```
 


### PR DESCRIPTION
## What changed

Restore the `silent` suffix in the FAQ workspace autostart example.

## Why

The Lua documentation migration replaced the previous `[workspace 1 silent]` exec rule with `{ workspace = "1" }`, but retained the statement that the example starts applications without flickering between workspaces. Without the suffix, Hyprland switches to the target workspace when the application opens.

This also resolves the behavior reported in [discussion #15255](https://github.com/hyprwm/Hyprland/discussions/15255).

## Impact

Users copying the example will launch the application on workspace 1 without switching away from their current workspace.

## Validation

- `git diff --check`
- Confirmed the workspace rule parser and integration tests use the `" silent"` suffix.