### PR TITLE
Fix typo in volume gesture example

### DIFF
--- a/content/Configuring/Advanced and Cool/Gestures.md
+++ b/content/Configuring/Advanced and Cool/Gestures.md
@@ -154,12 +154,12 @@ hl.gesture({
 -- Adjust volume
 local volume_gesture = function(change) hl.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ " .. math.abs(change) .. "%" .. (change<0 and "-" or "+")) end
 hl.gesture({
-  fingers = 3
+  fingers = 3,
   direction = "vertical",
   action = {
     start = function(e) volume_gesture(-0.25 * e.delta.y) end,
     update = function(e) volume_gesture(-0.25 * e.delta.y) end
-  },
+  }
 })
 ```
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on the README: https://github.com/hyprwm/hyprland-wiki?tab=readme-ov-file#contributing-to-the-wiki
-->

I blindly copy pasted the example code and my whole setup exploded :smile:

I also removed the trailing comma for *consistency*
