### PR TITLE
Configuring/Binds: warn that Lua keybind handlers must not block

### DIFF
--- a/content/Configuring/Basics/Binds.md
+++ b/content/Configuring/Basics/Binds.md
@@ -33,6 +33,15 @@ hl.bind("SUPER + SHIFT + X", function()
 end)
 ```
 
+> [!WARNING]
+> **Keybind handlers must not block.** Lua callbacks run on the compositor
+> event loop. Avoid `io.popen`, network I/O, clipboard tools (`wl-paste`,
+> `xclip`), sleeps, and other long-running work inside bind functions.
+> Prefer `hl.dsp.exec_cmd(...)` for external commands so they run outside
+> the bind callback. If you must probe the system from Lua, bound the wait
+> (for example with `timeout`). A hung or slow call freezes input and the
+> entire desktop until it returns.
+
 ## Uncommon syms / binding with a keycode
 
 See the


### PR DESCRIPTION
## Summary

Adds a warning on the Binds page that Lua keybind callbacks must not block.

Lua bind handlers run on the compositor event loop. Calling blocking tools
from a bind (for example `io.popen("wl-paste --list-types")` for a "smart
paste") can hang forever when the clipboard offer stalls, which freezes the
whole desktop. Stock key injection is fine; the footgun is easy with Lua
config and was not documented.

## Changes

- After the Lua function dispatcher example on `Configuring/Basics/Binds`,
  add a WARNING callout: avoid `io.popen` / network / clipboard probes in
  binds; prefer `hl.dsp.exec_cmd(...)`; bound any necessary waits.

## Test plan

- [x] Matches existing wiki callout style (`> [!WARNING]`)
- [x] Placed next to the Lua function bind example where readers will see it
- [ ] Render with `hugo serve` if maintainers want a visual check

Fixes #1622