### PR TITLE
Configuring/Advanced and Cool/Uncommon-tips-and-tricks: add vim-like keymaps section

### DIFF
--- a/content/Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md
+++ b/content/Configuring/Advanced and Cool/Uncommon-tips-and-tricks.md
@@ -184,7 +184,6 @@ end
 
 Bind to use cursor zoom like a glass magnifier
 
-
 ```lua
 local MAX_ZOOM = 3
 local MIN_ZOOM = 1
@@ -215,4 +214,44 @@ end)
 
 ```
 
+## Vim-like keymaps
 
+Hyprland has so many features that you might run out of keys on your keyboard if you want to bind them all. Rest assured, you can utilize submaps to create keymaps if you want more, and they're also easier to press.
+
+Here's an example of managing window groups this way:
+
+```lua
+hl.bind("SUPER + G", hl.dsp.submap("group_management"), { desc = "Enter a group management submap" })
+
+local map = function(key, action, desc)
+	hl.bind(key, function()
+		hl.dispatch(action)
+		hl.dispatch(hl.dsp.submap("reset"))
+	end, { desc = desc })
+end
+
+hl.define_submap("group_management", function()
+	map("g", hl.dsp.group.toggle(), "Toggle window group")
+
+	map("h", hl.dsp.window.move({ into_group = "l" }), "Move window into a group on the left")
+	map("j", hl.dsp.window.move({ into_group = "d" }), "Move window into a group on the bottom")
+	map("k", hl.dsp.window.move({ into_group = "u" }), "Move window into a group on the top")
+	map("l", hl.dsp.window.move({ into_group = "r" }), "Move window into a group on the right")
+
+	map("e", hl.dsp.window.move({ out_of_group = true }), "Move window out of group")
+
+	map("n", hl.dsp.group.next(), "Next window in group")
+	map("p", hl.dsp.group.prev(), "Previous window in group")
+
+	map("f", hl.dsp.group.move_window(), "Move window forward in the group order")
+	map("b", hl.dsp.group.move_window({ forward = false }), "Move window backward in the group order")
+
+	map("t", hl.dsp.group.lock_active(), "Toggle group lock")
+
+	for i = 1, 10 do
+		map(tostring(i % 10), hl.dsp.group.active({ index = i }), "Focus window " .. i .. " in a group")
+	end
+
+	hl.bind("escape", hl.dsp.submap("reset"), { desc = "Quit submap" })
+end)
+```


### PR DESCRIPTION
Just found out a cool way to use hyprland and I haven't seen it anywhere before, so I thought I might contribute since there's a great page for things like this in the wiki.