### PR TITLE
Getting Started/Installation: update minimum gcc version to 16

### DIFF
--- a/content/Getting Started/Installation.md
+++ b/content/Getting Started/Installation.md
@@ -286,7 +286,7 @@ Dependencies:
 
 > [!NOTE]
 > Please note that Hyprland uses the C++26 standard, so both your compiler and your
-> C++ standard library has to support that (`gcc>=15` or `clang>=19`).
+> C++ standard library has to support that (`gcc>=16` or `clang>=19`).
 
 {{% details title="Arch" closed="true" %}}
 


### PR DESCRIPTION
Update minimum required compiler version for Hyprland to gcc>=16.