### PR TITLE
Monitors: fix sdr_eotf docs

### DIFF
--- a/content/Configuring/Basics/Monitors.md
+++ b/content/Configuring/Basics/Monitors.md
@@ -219,7 +219,7 @@ All fields beyond `output` are optional and fall back to sensible defaults.
 | mirror | string | | Output name to mirror |
 | bitdepth | integer | 8 | Bit depth (8 or 10) |
 | cm | string | srgb | Color management preset |
-| sdr_eotf | string | default | SDR transfer function (default, gamma22, srgb) |
+| sdr_eotf | string | default | SDR transfer function (default, auto, srgb, gamma22, gamma22force) |
 | sdrbrightness | float | 1.0 | SDR brightness in HDR mode |
 | sdrsaturation | float | 1.0 | SDR saturation in HDR mode |
 | vrr | integer | 0 | VRR mode |
@@ -298,9 +298,18 @@ hl.monitor({
 })
 ```
 
-The default transfer function assumed to be in use on an SDR display for sRGB content is defined by `sdr_eotf`.
-The default (`"default"`) follows `render:cm_sdr_eotf`. This can be changed to piecewise sRGB with `"srgb"`,
-or Gamma 2.2 with `"gamma22"`.
+The transfer function assumed to be in use on an SDR display for content that does not
+specify one is defined by `sdr_eotf`:
+
+| Value | Behavior |
+| --- | --- |
+| `"default"` (or `"0"`) | Piecewise sRGB. Note this does **not** follow `render:cm_sdr_eotf`. |
+| `"auto"` | Follow the global `render:cm_sdr_eotf`. If that is also `auto`, Gamma 2.2 is used. |
+| `"srgb"` (or `"3"`) | Piecewise sRGB. |
+| `"gamma22"` (or `"1"`) | Treat unspecified as Gamma 2.2. |
+| `"gamma22force"` (or `"2"`) | Treat unspecified **and** sRGB as Gamma 2.2. |
+
+An unrecognized value silently falls back to `"default"`.
 
 ### ICC Profiles
 


### PR DESCRIPTION
The `sdr_eotf` docs describe behavior the code does not implement, and omit two of the five accepted values.

### `"default"` does not follow `render:cm_sdr_eotf`

The page currently states:

> The default (`"default"`) follows `render:cm_sdr_eotf`.

But `chooseTF()` in `src/output/Monitor.cpp` returns sRGB for `TF_DEFAULT` unconditionally — the global is only read in the `TF_AUTO` branch:

```cpp
case NTransferFunction::TF_DEFAULT:
case NTransferFunction::TF_SRGB: return NColorManagement::CM_TRANSFER_FUNCTION_SRGB;

case NTransferFunction::TF_AUTO: // use global setting
    switch (sdrEOTF) {
        case NTransferFunction::TF_AUTO: return NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22;
        default: return chooseTF(sdrEOTF);
    }
```

`Variables.md` already documents the global's `"default"` as "Use default value (sRGB)", which agrees with the code and contradicts this page.

### `"auto"` and `"gamma22force"` were undocumented

`fromString()` in `src/helpers/TransferFunction.cpp` accepts five names plus numeric aliases:

```cpp
{{"default", TF_DEFAULT}, {"0", TF_DEFAULT}, {"auto", TF_AUTO}, {"srgb", TF_SRGB},
 {"3", TF_SRGB}, {"gamma22", TF_GAMMA22}, {"1", TF_GAMMA22},
 {"gamma22force", TF_FORCED_GAMMA22}, {"2", TF_FORCED_GAMMA22}}
```

The value list said only `default, gamma22, srgb`. `"auto"` is the one users need to make the global option take effect, so its absence made `render:cm_sdr_eotf` look inert.

`gamma22force`'s distinction from `gamma22` (it also overrides content explicitly tagged sRGB) is per `Renderer.cpp:1926` and `Monitor.cpp:2504`, and matches the wording already in `Variables.md`.

### Unrecognized values fall back silently

`fromString()` returns `TF_DEFAULT` for anything not in the table, with no warning or config error. A plausible misspelling such as `gamma2.2` is therefore indistinguishable from the option having no effect — worth one sentence so others don't lose time to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxJCnu4paJffthUzEfFy3e