### PR TITLE
Dang it, LaTeX

### DIFF
--- a/content/nix/configuring-hyprland-with-hjem.md
+++ b/content/nix/configuring-hyprland-with-hjem.md
@@ -3,8 +3,8 @@ weight: 30
 title: Configuring Hyprland with Hjem
 ---
 
-Hjem ("home" in Danish) is a module system that implements a simple and streamlined way to manage files in your $HOME, such as but not limited to files in your `~/.config`.
-Hjem aims to serve as an alternative and easy-to-grasp utility for managing your $HOME purely and safely.
+Hjem ("home" in Danish) is a module system that implements a simple and streamlined way to manage files in your `$HOME`, such as but not limited to files in your `~/.config`.
+Hjem aims to serve as an alternative and easy-to-grasp utility for managing your `$HOME` purely and safely.
 
 You can read the wonderful [Hjem documentation](https://hjem.feel-co.org/) to learn how to install and use it.
 


### PR DESCRIPTION
Since we enabled LaTeX for math expressions, env vars (and their `$`) need to be codeblocked. That got skipped in one spot, on https://wiki.hypr.land/nix/configuring-hyprland-with-hjem/ :(