### PR TITLE
content/contributing-and-debugging/pr-guidelines.md: bring back the format command

### DIFF
--- a/content/contributing-and-debugging/pr-guidelines.md
+++ b/content/contributing-and-debugging/pr-guidelines.md
@@ -20,7 +20,7 @@ Please read this if you are submitting a PR, in order to minimize the amount of 
 
 ### Before you submit
 
-Make sure you ran clang-format: `clang-format -i $(find src -type f \( -name "*.cpp" -o -name "*.hpp" \))`
+Make sure you ran clang-format: `make format-fix`
 
 Check if your changes don't violate `clang-tidy`.
 Usually this is built into your IDE.

--- a/content/contributing-and-debugging/pr-guidelines.md
+++ b/content/contributing-and-debugging/pr-guidelines.md
@@ -20,7 +20,7 @@ Please read this if you are submitting a PR, in order to minimize the amount of 
 
 ### Before you submit
 
-Make sure you ran clang-format: `make format-check`
+Make sure you ran clang-format: `clang-format -i $(find src -type f \( -name "*.cpp" -o -name "*.hpp" \))`
 
 Check if your changes don't violate `clang-tidy`.
 Usually this is built into your IDE.


### PR DESCRIPTION
What's the point of checking if it fits formatting when you can just format it. It's not like you can make a passing MR without formatting.