### PR TITLE
Configuring/Naming conventions: document relative workspace search

### DIFF
--- a/content/configuring/naming-conventions.md
+++ b/content/configuring/naming-conventions.md
@@ -158,13 +158,31 @@ No spaces are allowed inside props themselves.
 
 #### Workspace search
 
-Workspace search is performed by suffixing search selector with workspace ID.
-To use absolute ID, `~` is put between selector and ID (e.g., `m~3`)
+> [!WARNING]
+> For `m`, `r`, and `e`, the sign is not optional.
+> `m3` is not a relative match: it falls through to a workspace *name* lookup, and does nothing unless a workspace is literally named `m3`.
+> Write `m+3`, `m-3`, or `m~3`.
+
+Workspace search is performed by suffixing a search selector with a signed offset, `+n` or `-n`, for a match relative to the active workspace.
+To use an absolute, 1-indexed ID instead, `~` is put between selector and ID (e.g., `m~3` is the third workspace on the current monitor).
 
 - `m` - Search for workspace on current monitor
 - `r` - Search for workspace on current monitor including empty/non-existant workspaces
 - `e` - Search on all monitors
 - `empty` - Search for first empty workspace. Suffix with `m` to only search on monitor, and/or `n` to make it the _next_ available empty workspace (e.g., `emptynm`)
+
+`m` and `e` only traverse workspaces that already exist, and they wrap around at both ends of that list.
+They can therefore never select an empty workspace that has not been created yet.
+`r` walks workspace IDs instead, so it can select an empty workspace, and it clamps at 1 rather than wrapping.
+
+Assuming workspaces 1 through 4 exist and 5 does not:
+
+| Selector | Active workspace | Result |
+| --- | --- | --- |
+| `e+1` | 4 | 1, wrapping around; never 5 |
+| `r+1` | 4 | 5, which is created |
+| `e-1` | 1 | 4, wrapping around |
+| `r-1` | 1 | 1, clamped |
 
 ### Direction
 


### PR DESCRIPTION
The **Workspace search** section currently describes the syntax as:

> Workspace search is performed by suffixing search selector with workspace ID.

That form does not work. `getWorkspaceIDNameFromString` requires the second character to be `+`, `-` or `~`:

```cpp
} else if ((in[0] == 'm' || in[0] == 'e') && (in[1] == '-' || in[1] == '+' || in[1] == '~') && isNumber(in.substr(2))) {
```

so an unsigned selector like `m3` falls through to the workspace *name* lookup at the end of the function, finds nothing, and silently does nothing. The working relative form (`m+1`, `e-1`, `r+2`) is not shown anywhere on the page.

This PR documents the signed relative form and adds the distinction that actually separates the three selectors, which is currently only visible in the source:

- `m` and `e` build their candidate list from workspaces that **already exist**, then wrap with `currentItem % validWSes.size()`. They can never select an empty workspace that has not been created yet.
- `r` walks workspace IDs, so it can select one that does not exist, and clamps at 1 instead of wrapping.

The `r` bullet already hints at this with "including empty/non-existant workspaces", but nothing states the corresponding limit on `m`/`e`, which makes `e+1` look like a general "next workspace" selector when it is not.

### Verification

Checked against the parser on `main`, and confirmed empirically on Hyprland `v0.56.2` (the function is identical on both; the only difference is the `BASEMONITOR` refactor). With workspaces 1-4 existing and 5 not:

| Selector | Active workspace | Result |
| --- | --- | --- |
| `e+1` | 4 | 1, wrapping around; never 5 |
| `r+1` | 4 | 5, which is created |
| `e-1` | 1 | 4, wrapping around |
| `r-1` | 1 | 1, clamped |

`m3` and `e3` were also confirmed to be no-ops.