### PR TITLE
Nix: general updates and clarifications

### DIFF
--- a/content/getting-started/installation.md
+++ b/content/getting-started/installation.md
@@ -37,6 +37,12 @@ If you get `.so` file mismatch/missing errors, it's _entirely your fault_ for do
 However, if you are an experienced user and want to beta-test new features, you're more than welcome to run the latest git head.
 Please don't come asking about ".so file missing" errors though!
 
+[Nix](../../nix/hyprland-on-any-distro-using-nix) fixes this.
+This is for more advanced users comfortable with running scripts.
+If you are on a distro that has subpar support for Hyprland, consider installing the Nix package manager.
+It solves the problems of mismatching `.so` files as well as library conflicts in general, and ensures your packages stay up to date.
+It is supported by all distros that use systemd and does not interfere with or replace your current package manager.
+
 ### Packages
 
 > [!WARNING]

--- a/content/nix/_index.md
+++ b/content/nix/_index.md
@@ -3,12 +3,15 @@ weight: 80
 title: Nix
 ---
 
-## Installing Hyprland on Nixos
+## Installing Hyprland on NixOS
 
-See [Hyprland on NixOS](./installing-hyprland-on-nixos).
+If you are already on NixOS or plan on writing a config for it, see [Hyprland on NixOS](./installing-hyprland-on-nixos).
 
-## Using Hyprland on any distro with the Nix package manager
+## Using Hyprland on any other distro with the Nix package manager
 
+If you want to use Hyprland but you are on a distro without official support, you can install just Nix itself --- the package manager.
+This will provide a better experience and be guaranteed to be up to date, especially on point-release distros.
+It is also simpler than compiling from source and allows you to use the binary cache, which is important for lower-spec devices. 
 See [this page](./hyprland-on-any-distro-using-nix).
 
 ## Advanced

--- a/content/nix/configuring-hyprland-with-hjem.md
+++ b/content/nix/configuring-hyprland-with-hjem.md
@@ -14,7 +14,7 @@ Here follows an example of how to write your `hyprland.lua` contents directly in
 
 ```lua {filename="hyprland.nix"}
 {
-    hjem.users.youruser.files.".config/hypr/hyprland.lua".text = /* lua */ ''
+    hjem.users.youruser.xdg.config.files."hypr/hyprland.lua".text = /* lua */ ''
       # Your hyprland.lua content goes here.
       # You can use string interpolation for Nix to evaluate variables at build time.
       # A snippet of a hyprland.lua config using string interpolation for some variables to be interpreted by Nix:
@@ -30,8 +30,33 @@ Here follows an example of how to write your `hyprland.lua` contents directly in
 
 ## Sourcing a hyprland.lua file at your Nix config
 
-Instead of writing your `hyprland.lua` contents directly inside your Nix config, you also have the possibility of sourcing a `hyprland.lua` file using Hjem, to link it into its place at `~/.config/hypr/`.
+Instead of writing your `hyprland.lua` contents directly inside your Nix config, you also have the possibility of sourcing an already existing `hyprland.lua` file using Hjem, to link it into its place at `~/.config/hypr/`.
+If using version control, make sure this `hyprland.lua` is in the same repository as your config.
 However, you can't use Nix string interpolation this way.
+
+```nix {filename="hyprland.nix"}
+{
+    hjem.users.youruser.xdg.config.files."hypr/hyprland.lua".source = ./relative/path/to/file;
+}
+```
+
+If you have already split your `hyprland.lua` into multiple files, you may source them the same way.
+
+```nix {filename="hyprland.nix"}
+{
+    hjem.users.youruser.xdg.config.files = {
+        "hypr/hyprland.lua".source = ./relative/path/to/hyprland.lua;
+        "hypr/rules.lua".source = ./relative/path/to/rules.lua;
+        "hypr/keybinds.lua".source = ./relative/path/to/keybinds.lua;
+        "hypr/animations.lua".source = ./relative/path/to/animations.lua;
+    };
+}
+```
+
+For multi-file examples such as the one above, you may prefer to just link a whole directory. 
+While you can do that in Hjem, it comes with the caveat that it makes the whole directory read-only.
+This can be undesirable as it blocks any new files from being made inside that directory, breaking certain apps.
+If you would like to recursively link only the files from inside a directory, [FindFiles](#findfiles) will interest you.
 
 ## Hjem-impure
 
@@ -45,3 +70,14 @@ So after that, you can write into your `~/.config/hyprland.lua` file deployed by
 **This enables experimentation.**
 What this means is that, after a NixOS build switch or after a system reboot, the changes that you made in `~/.config/hyprland.lua` **will be gone**.
 So after you are happy with your changes, write them into your Nix config for them to be persisted.
+
+## FindFiles
+
+[FindFiles](https://github.com/Michael-C-Buckley/findFiles.nix) is a small Nix library that allows you to easily link whole directories from inside your configuration to the correct locations.
+It combines with a home management tool such as Hjem, which manages the linking itself, but it recursively finds files inside a directory.
+This way you are linking every file in a folder instead of the folder itself all with one line of code.
+Normal directory linking with Hjem links the whole folder, meaning the folder becomes read-only.
+It works well with Hjem-impure if you desire hot reloading.
+An example of what you can do with FindFiles:
+- Have a config directory inside your repository and have it overlay on your entire `~/.config`.
+- Have a Hyprland directory that gets auto-placed at `~/.config/hypr/`.

--- a/content/nix/hyprland-on-any-distro-using-nix.md
+++ b/content/nix/hyprland-on-any-distro-using-nix.md
@@ -5,24 +5,48 @@ title: Hyprland on any distro using Nix
 
 Using Hyprland via the Nix package manager on distros that aren't NixOS is very simple.
 
-First, install Nix with your distro native package manager, be that `apt`, `pacman`, `dnf`, etc.
-The package is almost always called `nix`.
+## Installing Nix
 
-For example:
+The first step is to install Nix itself.
+There are two primary ways to install the Nix package manager:
+
+{{% tabs %}}
+
+{{% tab name="From Upstream" %}}
+
+Nix upstream recommends the multi-user installer, which can be found in their [official documentation](https://nixos.org/manual/nix/stable/installation/index.html).
+It operates outside of your package manager's control and modifies your shell profiles directly.
+Uninstalling this method is harder.
+The install script requires a distro that uses systemd.
+
+{{% /tab %}}
+
+{{% tab name="From Your Distro" %}}
+
+Install Nix using your package manager, be that `apt`, `pacman`, `dnf`, etc.
+The package is almost always called `nix`.
+This integrates cleanly with your OS and is as easy to uninstall as any other package.
+However, because it relies on dynamically linked libraries, an incompatible system update could potentially break Nix.
+Additionally, you must rely on your distro's maintainers to package and push Nix updates rather than getting them directly from upstream.
+
+For example, to install with pacman:
 
 ```sh
 sudo pacman -S nix
 ```
 
-Then enable the daemon:
+After installing, you must manually enable the daemon.
+For users on a systemd distro, use this command:
 
 ```sh
 sudo systemctl enable --now nix-daemon
 ```
 
-Advanced users might want to use [Home Manager](../configuring-hyprland-with-home-manager).
-If you don't know what this is, just don't.
+{{% /tab %}}
 
+{{% /tabs %}}
+
+## Installing Hyprland
 Before you do anything, [enable flakes](https://nixos.wiki/wiki/Flakes#Enable_flakes), by adding this to `/etc/nix/nix.conf` or `~/.config/nix/nix.conf`:
 
 ```nix

--- a/content/nix/installing-hyprland-on-nixos.md
+++ b/content/nix/installing-hyprland-on-nixos.md
@@ -114,37 +114,21 @@ in {
 
 ## Configuring Hyprland on NixOS
 
-You need to choose one of the three ways for configuring Hyprland in Nix: Hjem, home manager, or the upstream module.
+There are two ways to configure Hyprland in Nix declaratively.
+You can still do it imperatively by simply putting your `hyprland.lua` in `~/.config/hypr/`.
+While that is not the recommended method, it is still an option in which neither of the two ways described below are needed.
 
 ### Hjem
 
-Read [Configuring Hyprland with Hjem](../configuring-hyprland-with-hjem).
+Hjem is a simple, lightweight home management tool designed for linking files into your home directory and setting systemd units and environment variables at the user level.
+[Configuring Hyprland with Hjem](../configuring-hyprland-with-hjem).
 
 ### Home Manager
 
-Read [Configuring Hyprland with Home Manager](../configuring-hyprland-with-home-manager).
+Home Manager is a popular home management tool for Nix that comes with a lot of bells and whistles.
+It allows for configuring a range of apps with pure Nix code, which may be desired.
+[Configuring Hyprland with Home Manager](../configuring-hyprland-with-home-manager).
 
 For the adventurous, [@spikespaz](https://github.com/spikespaz) has made a Hyprland module that can be used in Home Manager and NixOS.
 It can be found [here](https://github.com/hyprland-community/hyprnix).
-
-### The upstream module
-
-The [upstream module](https://github.com/hyprwm/Hyprland/blob/main/nix/module.nix) provides options similar to the ones in the Home Manager module.
-
-To use it, simply add
-
-```nix
-{inputs, ...}: {
-  imports = [inputs.hyprland.nixosModules.default];
-
-  programs.hyprland = {
-    # usual Nixpkgs module options
-    plugins = [
-      #...
-    ];
-    settings = {
-      # ...
-    };
-  };
-}
 ```


### PR DESCRIPTION
Key changes:
- Installation: Added a recommendation to use Nix on unsupported distributions to avoid .so mismatch and library conflict issues.
- Non-NixOS setup: Added the official multi-user installer as the recommended installation method
- NixOS setup: Clarified the differences between Hjem, Home Manager, and the upstream module, and explicitly noted that standard imperative configuration remains an option.
- Hjem: Added examples for sourcing split/multi-file configurations.

I also included a reference to FindFiles (a small community helper library written by Jet) in the Hjem section, since it solves the read-only directory issue when linking folders. Let me know if thats a problem.